### PR TITLE
Trigger Burrow 0.3.7 release

### DIFF
--- a/.github/workflows/publish-037.yml
+++ b/.github/workflows/publish-037.yml
@@ -1,3 +1,4 @@
+# Triggered through release pull request
 name: Publish Burrow 0.3.7 beta
 
 on:


### PR DESCRIPTION
Triggers the tested Burrow 0.3.7 beta publishing workflow.