### PR TITLE
Run Burrow 0.3.8 beta release

### DIFF
--- a/.github/burrow-release/trigger-038
+++ b/.github/burrow-release/trigger-038
@@ -1,0 +1,1 @@
+Run Burrow 0.3.8 beta release.

--- a/.github/burrow-release/trigger-038
+++ b/.github/burrow-release/trigger-038
@@ -2,3 +2,4 @@ Run Burrow 0.3.8 beta release.
 Trigger synchronized after workflow registration.
 Second synchronization attempt.
 Run with pull request target.
+Git data API synchronization.

--- a/.github/burrow-release/trigger-038
+++ b/.github/burrow-release/trigger-038
@@ -1,3 +1,4 @@
 Run Burrow 0.3.8 beta release.
 Trigger synchronized after workflow registration.
 Second synchronization attempt.
+Run with pull request target.

--- a/.github/burrow-release/trigger-038
+++ b/.github/burrow-release/trigger-038
@@ -1,1 +1,2 @@
 Run Burrow 0.3.8 beta release.
+Trigger synchronized after workflow registration.

--- a/.github/burrow-release/trigger-038
+++ b/.github/burrow-release/trigger-038
@@ -1,2 +1,3 @@
 Run Burrow 0.3.8 beta release.
 Trigger synchronized after workflow registration.
+Second synchronization attempt.


### PR DESCRIPTION
Triggers the 0.3.8 beta packaging, validation, tag, and prerelease workflow.