### PR TITLE
Finalize Burrow 0.3.8 beta release

### DIFF
--- a/.github/release-038-final-trigger
+++ b/.github/release-038-final-trigger
@@ -1,0 +1,1 @@
+Publish Burrow 0.3.8 beta.

--- a/.github/workflows/publish-038-final.yml
+++ b/.github/workflows/publish-038-final.yml
@@ -1,0 +1,80 @@
+name: Publish Burrow 0.3.8 beta
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/release-038-final-trigger
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Validate release source
+        shell: bash
+        run: |
+          set -euo pipefail
+          grep -F 'VERSION = "0.3.8-beta"' plugins/burrow.koplugin/burrow_version.lua
+          grep -F 'DISPLAY_VERSION = "0.3.8 beta"' plugins/burrow.koplugin/burrow_version.lua
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq lua5.1 zip
+          find plugins/burrow.koplugin -type f -name '*.lua' -print0 | xargs -0 -n1 luac5.1 -p
+
+      - name: Build release files
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist/stage
+          cp -a plugins dist/stage/
+          cp NOTICE.md dist/stage/
+          (
+            cd dist/stage
+            find plugins NOTICE.md -type f -print0 | sort -z | xargs -0 sha256sum > FILES.sha256
+            zip -qr ../Burrow-0.3.8-beta.zip plugins NOTICE.md FILES.sha256
+          )
+          sha256sum dist/Burrow-0.3.8-beta.zip > dist/Burrow-0.3.8-beta.zip.sha256
+          unzip -t dist/Burrow-0.3.8-beta.zip
+
+      - name: Remove temporary publisher
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git rm .github/workflows/publish-038-final.yml .github/release-038-final-trigger
+          git commit -m "Finalize Burrow 0.3.8 beta release"
+          git push origin HEAD:main
+
+      - name: Create tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          git tag -a v0.3.8-beta -m "Burrow 0.3.8 beta"
+          git push origin v0.3.8-beta
+
+      - name: Create GitHub prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh release create v0.3.8-beta \
+            dist/Burrow-0.3.8-beta.zip \
+            dist/Burrow-0.3.8-beta.zip.sha256 \
+            --verify-tag \
+            --title "Burrow 0.3.8 beta" \
+            --prerelease \
+            --notes-file - <<'EOF'
+          Burrow 0.3.8 beta keeps the Home and Store footer at one consistent size, makes the Store respect the configured Home and Store label-size setting, and standardizes the active underline across both screens.
+
+          Back up the KOReader data folder before upgrading. Replace the existing `plugins/burrow.koplugin` folder and fully restart KOReader.
+          EOF


### PR DESCRIPTION
Adds a one-time publisher that validates the 0.3.8 beta source, builds the ZIP and checksum, creates the v0.3.8-beta tag, publishes the GitHub prerelease, and removes the temporary publishing files.