### PR TITLE
Trigger Burrow 0.3.8 prerelease

### DIFF
--- a/.github/release-038-pr-trigger
+++ b/.github/release-038-pr-trigger
@@ -1,1 +1,2 @@
 Run the final Burrow 0.3.8 beta publication.
+Synchronize after pull request workflow registration.

--- a/.github/release-038-pr-trigger
+++ b/.github/release-038-pr-trigger
@@ -1,0 +1,1 @@
+Run the final Burrow 0.3.8 beta publication.


### PR DESCRIPTION
Triggers the final validated 0.3.8 beta packaging, tag, and GitHub prerelease workflow.