### PR TITLE
Publish Burrow 0.4.2-beta.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to Burrow will be documented here.
 
 ## [Unreleased]
 
+## [0.4.2-beta.10] - 2026-08-13
+
+### Changed
+
+- Replaced the Quick Settings Restart glyph with a power-style icon so Restart is visually distinct from Rotate
+- Replaced the older arrow-based paged-dialog footers with Burrow's Home-style page indicator: a long active pill with small inactive dots
+- Centered the Table of Contents page indicator at the bottom of the screen to match the Home library pager
+
+### Fixed
+
+- Restored four-way Quick Settings rotation so Rotate cycles through all four physical screen orientations
+- Restored rotation persistence between the library and reader
+- Persisted the selected orientation across a full KOReader restart by saving and explicitly restoring the File Manager rotation while rotation locking is enabled
+- Restored grid minimums down to one row or one column, allowing layouts such as 2x1, 1x3, and other rectangular combinations while retaining the 8x8 maximum
+- Improved automatic update checks so enabling Automatic update checks can immediately run a due check
+- Improved automatic update checks when KOReader starts offline by checking again after network connectivity becomes available
+- Kept automatic update checks on their recurring schedule while KOReader remains open
+- Added retry scheduling after failed automatic checks without allowing checks to run more frequently than hourly
+- Updated Book Information pagination to use the Home-style swipe-and-dots interface
+- Updated Table of Contents pagination to use the Home-style swipe-and-dots interface
+
+## [0.4.2-beta.9] - 2026-08-13
+
+### Changed
+
+- Promoted the updater, rotation, and grid recovery work to the prerelease channel for device testing
+
+### Fixed
+
+- Restored four-way Quick Settings rotation
+- Restored remembered rotation between File Manager and Reader
+- Restored one-row and one-column grid configurations
+- Improved automatic update-check triggering for the beta update channel
+
 ## [0.4.1] - 2026-08-12
 
 ### Changed
@@ -205,7 +239,10 @@ All notable changes to Burrow will be documented here.
 
 - Initial unified Burrow library, Store, and reader-interface package
 
-[Unreleased]: https://github.com/richbeatty/burrow.koplugin/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/richbeatty/burrow.koplugin/compare/v0.4.2-beta.10...HEAD
+[0.4.2-beta.10]: https://github.com/richbeatty/burrow.koplugin/releases/tag/v0.4.2-beta.10
+[0.4.2-beta.9]: https://github.com/richbeatty/burrow.koplugin/releases/tag/v0.4.2-beta.9
+[0.4.1]: https://github.com/richbeatty/burrow.koplugin/releases/tag/v0.4.1
 [0.4.0]: https://github.com/richbeatty/burrow.koplugin/releases/tag/v0.4.0
 [0.3.8-beta]: https://github.com/richbeatty/burrow.koplugin/releases/tag/v0.3.8-beta
 [0.3.7-beta]: https://github.com/richbeatty/burrow.koplugin/releases/tag/v0.3.7-beta

--- a/plugins/burrow.koplugin/burrow_quick_settings_rotation.lua
+++ b/plugins/burrow.koplugin/burrow_quick_settings_rotation.lua
@@ -6,10 +6,10 @@ local logger = require("logger")
 local RotationFix = {}
 
 function RotationFix.apply()
-    if UIManager._burrow_quick_rotation_v2 then
+    if UIManager._burrow_quick_rotation_v3 then
         return true
     end
-    UIManager._burrow_quick_rotation_v2 = true
+    UIManager._burrow_quick_rotation_v3 = true
 
     local Screen = Device.screen
     local original_broadcast = UIManager.broadcastEvent
@@ -26,25 +26,45 @@ function RotationFix.apply()
             and calledFromBurrowQuickSettings()
 
         if burrow_rotate then
-            -- Burrow's Rotate button should cycle through every physical side,
-            -- not only swap between the paired portrait/landscape orientations.
+            -- Cycle through all four physical orientations instead of KOReader's
+            -- paired portrait/landscape SwapRotation behavior.
             event = Event:new("IterateRotation")
-            -- Keep the selected orientation when moving between File Manager and
-            -- Reader, instead of letting per-view defaults rotate it again.
+
+            -- Keep this orientation when moving between File Manager and Reader.
             G_reader_settings:makeTrue("lock_rotation")
         end
 
         local result = original_broadcast(self, event, ...)
 
         if burrow_rotate then
-            -- File Manager reads this setting on launch. Saving the post-rotation
-            -- mode makes the last side chosen from Quick Settings survive a full
-            -- KOReader restart as well as reader/file-browser transitions.
-            G_reader_settings:saveSetting("fm_rotation_mode", Screen:getRotationMode())
-            logger.dbg("[Burrow] Saved Quick Settings rotation", Screen:getRotationMode())
+            -- Persist the actual post-rotation mode as Burrow's startup rotation.
+            -- KOReader normally skips fm_rotation_mode at startup when
+            -- lock_rotation is enabled, so Burrow also restores this value below.
+            local mode = Screen:getRotationMode()
+            G_reader_settings:saveSetting("fm_rotation_mode", mode)
+            if type(G_reader_settings.flush) == "function" then
+                G_reader_settings:flush()
+            end
+            logger.dbg("[Burrow] Saved Quick Settings rotation", mode)
         end
 
         return result
+    end
+
+    -- KOReader's FileManager:setRotationMode() intentionally does nothing when
+    -- lock_rotation is true. That is correct while switching views, but on a
+    -- fresh KOReader process it means the saved fm_rotation_mode is never
+    -- reapplied. Restore it once after Burrow starts so a full KOReader restart
+    -- comes back on the same physical side chosen from Quick Settings.
+    local saved_mode = tonumber(G_reader_settings:readSetting("fm_rotation_mode"))
+    if G_reader_settings:isTrue("lock_rotation") and saved_mode ~= nil then
+        saved_mode = saved_mode % 4
+        UIManager:nextTick(function()
+            if Screen:getRotationMode() ~= saved_mode then
+                original_broadcast(UIManager, Event:new("SetRotationMode", saved_mode))
+                logger.dbg("[Burrow] Restored saved startup rotation", saved_mode)
+            end
+        end)
     end
 
     return true

--- a/plugins/burrow.koplugin/burrow_updater_entry.lua
+++ b/plugins/burrow.koplugin/burrow_updater_entry.lua
@@ -8,6 +8,16 @@ if rotation_ok and RotationFix and type(RotationFix.apply) == "function" then
     pcall(RotationFix.apply)
 end
 
+-- Apply Burrow's Home-style page dots to KOReader's paginated Menu and
+-- KeyValuePage widgets. This remains a separate guarded module so the tested
+-- pager implementation can be updated without replacing KOReader's widgets.
+local source = debug.getinfo(1, "S").source
+local plugin_root = source:match("^@(.+)/[^/]+$") or "."
+local pager_ok, Pager = pcall(dofile, plugin_root .. "/internal_patches/2-dialog-pager-icons.lua")
+if pager_ok and Pager and type(Pager.apply) == "function" then
+    pcall(Pager.apply)
+end
+
 local function cleanError(err)
     return tostring(err or "unknown error"):gsub("^.-:%d+:%s*", "")
 end

--- a/plugins/burrow.koplugin/burrow_version.lua
+++ b/plugins/burrow.koplugin/burrow_version.lua
@@ -1,6 +1,6 @@
 return {
-    VERSION = "0.4.2-beta.9",
-    DISPLAY_VERSION = "0.4.2-beta.9",
+    VERSION = "0.4.2-beta.10",
+    DISPLAY_VERSION = "0.4.2-beta.10",
     STORE_ENGINE_VERSION = "1.2.1",
 
     -- Burrow is tested against KOReader 2026.07.2. Older releases are blocked,

--- a/plugins/burrow.koplugin/icons/quick_restart.svg
+++ b/plugins/burrow.koplugin/icons/quick_restart.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g fill="none" stroke="#000" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M19 8a8 8 0 1 0 1 7"/><path d="M19 4v4h-4"/></g></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g fill="none" stroke="#000" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v8"/><path d="M7.1 5.6a8 8 0 1 0 9.8 0"/></g></svg>

--- a/plugins/burrow.koplugin/internal_patches/2-dialog-pager-icons.lua
+++ b/plugins/burrow.koplugin/internal_patches/2-dialog-pager-icons.lua
@@ -1,0 +1,220 @@
+local MODULE_KEY = "burrow.internal.2_dialog_pager_icons"
+local existing_module = package.loaded[MODULE_KEY]
+if existing_module then return existing_module end
+
+local Blitbuffer = require("ffi/blitbuffer")
+local CenterContainer = require("ui/widget/container/centercontainer")
+local Geom = require("ui/geometry")
+local KeyValuePage = require("ui/widget/keyvaluepage")
+local Menu = require("ui/widget/menu")
+local Screen = require("device").screen
+local Widget = require("ui/widget/widget")
+
+local Module = { key = MODULE_KEY, phase = "early", filename = "2-dialog-pager-icons.lua" }
+package.loaded[MODULE_KEY] = Module
+
+-- Same visual language as Burrow's Home pager: a dark elongated pill for the
+-- current page and small light-gray dots for the surrounding pages. Paging is
+-- intentionally gesture-first; KOReader's existing horizontal swipe handlers
+-- remain untouched.
+local PageDots = Widget:extend {
+    page = 1,
+    page_num = 1,
+    max_visible = 9,
+    dimen = nil,
+}
+
+function PageDots:init()
+    self.dot_size = self.dot_size or math.max(3, Screen:scaleBySize(3))
+    self.active_width = self.active_width
+        or math.max(self.dot_size * 2, math.floor(self.dot_size * 2.5))
+    self.gap = self.gap or math.max(5, math.floor(self.dot_size * 1.6))
+    self.height = self.height or math.max(self.dot_size, Screen:scaleBySize(10))
+end
+
+function PageDots:_visiblePages()
+    local total = math.max(1, tonumber(self.page_num) or 1)
+    local current = math.max(1, math.min(total, tonumber(self.page) or 1))
+    local count = math.min(total, self.max_visible)
+    local first = 1
+    if total > count then
+        first = math.max(1, math.min(current - math.floor(count / 2), total - count + 1))
+    end
+    local pages = {}
+    for value = first, first + count - 1 do
+        pages[#pages + 1] = value
+    end
+    return pages, current
+end
+
+function PageDots:getSize()
+    local pages, current = self:_visiblePages()
+    local width = 0
+    for index, page in ipairs(pages) do
+        width = width + (page == current and self.active_width or self.dot_size)
+        if index < #pages then
+            width = width + self.gap
+        end
+    end
+    return Geom:new { w = math.max(1, width), h = math.max(1, self.height) }
+end
+
+function PageDots:setPage(page, page_num)
+    self.page = page or 1
+    self.page_num = page_num or 1
+    self.dimen = nil
+end
+
+-- Compatibility methods. KOReader's Menu and KeyValuePage update routines still
+-- talk to page_info_text as though it were a Button. We deliberately ignore the
+-- old text/enable state and render only the Home-style page indicator.
+function PageDots:setText() end
+function PageDots:enable() end
+function PageDots:disable() end
+function PageDots:disableWithoutDimming() end
+function PageDots:enableDisable() end
+function PageDots:show() end
+function PageDots:hide() end
+
+function PageDots:paintTo(bb, x, y)
+    local size = self:getSize()
+    if not self.dimen then
+        self.dimen = Geom:new { x = x, y = y, w = size.w, h = size.h }
+    else
+        self.dimen.x = x
+        self.dimen.y = y
+        self.dimen.w = size.w
+        self.dimen.h = size.h
+    end
+
+    local pages, current = self:_visiblePages()
+    local offset = 0
+    local dot_y = y + math.floor((self.height - self.dot_size) / 2)
+    for index, page in ipairs(pages) do
+        local width = page == current and self.active_width or self.dot_size
+        local color = page == current and Blitbuffer.COLOR_BLACK or Blitbuffer.COLOR_LIGHT_GRAY
+        bb:paintRoundedRect(
+            x + offset,
+            dot_y,
+            width,
+            self.dot_size,
+            color,
+            math.floor(self.dot_size / 2)
+        )
+        offset = offset + width
+        if index < #pages then
+            offset = offset + self.gap
+        end
+    end
+end
+
+-- Zero-size stand-ins for the four stock pager buttons. KOReader can continue
+-- calling show/hide/enableDisable on them, but they contribute no visible glyph
+-- and no width to the pager footer.
+local BlankPagerControl = Widget:extend { dimen = nil }
+function BlankPagerControl:init()
+    self.dimen = Geom:new { w = 0, h = 0 }
+end
+function BlankPagerControl:getSize() return self.dimen end
+function BlankPagerControl:paintTo() end
+function BlankPagerControl:show() end
+function BlankPagerControl:hide() end
+function BlankPagerControl:enable() end
+function BlankPagerControl:disable() end
+function BlankPagerControl:disableWithoutDimming() end
+function BlankPagerControl:enableDisable() end
+
+local function primePager(widget)
+    if widget._burrow_page_dots then return end
+    local dots = PageDots:new { show_parent = widget.show_parent or widget }
+    widget._burrow_page_dots = dots
+    widget.page_info_text = dots
+    widget.page_info_left_chev = BlankPagerControl:new {}
+    widget.page_info_right_chev = BlankPagerControl:new {}
+    widget.page_info_first_chev = BlankPagerControl:new {}
+    widget.page_info_last_chev = BlankPagerControl:new {}
+end
+
+local function refreshMenuDots(widget)
+    if not widget._burrow_page_dots then return end
+
+    local dots = widget._burrow_page_dots
+    dots:setPage(widget.page or 1, widget.page_num or 1)
+
+    -- ReaderToc uses Menu's footer, which is naturally right-biased by the
+    -- stock pager group. Keep the existing footer object (the BottomContainer
+    -- already references it), but replace its children with one full-width
+    -- CenterContainer. This makes the indicator sit at the true horizontal
+    -- center, exactly like Burrow's Home page dots.
+    if widget.page_info then
+        local width = widget.inner_dimen and widget.inner_dimen.w
+            or widget.dimen and widget.dimen.w
+            or Screen:getWidth()
+        local height = dots:getSize().h
+
+        for index = #widget.page_info, 1, -1 do
+            widget.page_info[index] = nil
+        end
+        widget.page_info[1] = CenterContainer:new {
+            dimen = Geom:new { w = width, h = height },
+            dots,
+        }
+        if widget.page_info.resetLayout then
+            widget.page_info:resetLayout()
+        end
+    end
+end
+
+local function refreshKeyValueDots(widget)
+    if widget._burrow_page_dots then
+        widget._burrow_page_dots:setPage(widget.show_page or 1, widget.pages or 1)
+        if widget.page_info and widget.page_info.resetLayout then
+            widget.page_info:resetLayout()
+        end
+    end
+end
+
+function Module.apply()
+    if Module.applied then return true end
+
+    if not Menu._burrow_dialog_page_dots then
+        Menu._burrow_dialog_page_dots = true
+        local original_init = Menu.init
+        function Menu:init(...)
+            primePager(self)
+            local result = original_init(self, ...)
+            refreshMenuDots(self)
+            return result
+        end
+
+        local original_update_items = Menu.updateItems
+        function Menu:updateItems(...)
+            local result = original_update_items(self, ...)
+            refreshMenuDots(self)
+            return result
+        end
+    end
+
+    if not KeyValuePage._burrow_dialog_page_dots then
+        KeyValuePage._burrow_dialog_page_dots = true
+        local original_init = KeyValuePage.init
+        function KeyValuePage:init(...)
+            primePager(self)
+            local result = original_init(self, ...)
+            refreshKeyValueDots(self)
+            return result
+        end
+
+        local original_populate = KeyValuePage._populateItems
+        function KeyValuePage:_populateItems(...)
+            local result = original_populate(self, ...)
+            refreshKeyValueDots(self)
+            return result
+        end
+    end
+
+    Module.applied = true
+    return true
+end
+
+return Module


### PR DESCRIPTION
Promotes the device-tested beta.10 fixes onto the prerelease branch only. Stable main remains untouched.

Includes four-way and cold-restart rotation persistence, the power-style Restart icon, restored 1-row/1-column grid support from beta.9, the automatic updater fixes from beta.9, and the approved Home-style swipe-and-dots pagination for Book Information and Table of Contents.

The full beta.10 and beta.9 change history is included in CHANGELOG.md.

Validation before this PR: exact beta.9 release package used as the base, all Lua files syntax-checked, Restart SVG parsed, and the resulting beta.10 diff verified to contain only the intended six files.