### PR TITLE
Publish Burrow 0.4.2-beta.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Burrow will be documented here.
 
 ## [Unreleased]
 
+## [0.4.2-beta.11] - 2026-08-13
+
+### Fixed
+
+- Prevented Quick Settings swipes from activating action tiles when a swipe ends over a button
+- Kept frontlight and warmth slider dragging functional while consuming other Quick Settings swipes
+- Scoped the Home-style Menu pager replacement to Table of Contents instead of modifying every KOReader Menu
+- Restored the Home and Store footer while browsing Store after the beta.10 pager regression
+- Prevented the beta.10 pager customization from interfering with unrelated KOReader menus
+
 ## [0.4.2-beta.10] - 2026-08-13
 
 ### Changed
@@ -239,7 +249,8 @@ All notable changes to Burrow will be documented here.
 
 - Initial unified Burrow library, Store, and reader-interface package
 
-[Unreleased]: https://github.com/richbeatty/burrow.koplugin/compare/v0.4.2-beta.10...HEAD
+[Unreleased]: https://github.com/richbeatty/burrow.koplugin/compare/v0.4.2-beta.11...HEAD
+[0.4.2-beta.11]: https://github.com/richbeatty/burrow.koplugin/releases/tag/v0.4.2-beta.11
 [0.4.2-beta.10]: https://github.com/richbeatty/burrow.koplugin/releases/tag/v0.4.2-beta.10
 [0.4.2-beta.9]: https://github.com/richbeatty/burrow.koplugin/releases/tag/v0.4.2-beta.9
 [0.4.1]: https://github.com/richbeatty/burrow.koplugin/releases/tag/v0.4.1

--- a/plugins/burrow.koplugin/burrow_updater_entry.lua
+++ b/plugins/burrow.koplugin/burrow_updater_entry.lua
@@ -1,26 +1,61 @@
 local Updater = require("burrow_updater_prepare_fix")
 Updater = require("burrow_updater_auto").apply(Updater)
 
--- Restore Burrow's original four-way, persistent Quick Settings rotation
--- behavior without changing KOReader's native SwapRotation action globally.
 local rotation_ok, RotationFix = pcall(require, "burrow_quick_settings_rotation")
 if rotation_ok and RotationFix and type(RotationFix.apply) == "function" then
     pcall(RotationFix.apply)
 end
 
--- Apply Burrow's Home-style page dots to KOReader's paginated Menu and
--- KeyValuePage widgets. This remains a separate guarded module so the tested
--- pager implementation can be updated without replacing KOReader's widgets.
 local source = debug.getinfo(1, "S").source
 local plugin_root = source:match("^@(.+)/[^/]+$") or "."
 local pager_ok, Pager = pcall(dofile, plugin_root .. "/internal_patches/2-dialog-pager-icons.lua")
 if pager_ok and Pager and type(Pager.apply) == "function" then
     pcall(Pager.apply)
+
+    -- beta.10 reached Table of Contents by wrapping every Menu. Recover the
+    -- stock Menu functions and the tested pager helpers from that wrapper, then
+    -- keep the Menu dots only on Table of Contents. KeyValuePage remains as-is.
+    local Menu = require("ui/widget/menu")
+    local _ = require("gettext")
+    local function upvalue(fn, wanted)
+        if type(fn) ~= "function" then return nil end
+        for index = 1, 64 do
+            local name, value = debug.getupvalue(fn, index)
+            if not name then break end
+            if name == wanted then return value end
+        end
+    end
+
+    local wrapped_init = Menu.init
+    local wrapped_update = Menu.updateItems
+    local original_init = upvalue(wrapped_init, "original_init")
+    local original_update = upvalue(wrapped_update, "original_update_items")
+    local primePager = upvalue(wrapped_init, "primePager")
+    local refreshMenuDots = upvalue(wrapped_init, "refreshMenuDots")
+        or upvalue(wrapped_update, "refreshMenuDots")
+    local toc_title = _("Table of contents")
+
+    if original_init and original_update and primePager and refreshMenuDots then
+        function Menu:init(...)
+            local title = type(self.title) == "string" and self.title or ""
+            local use_dots = title:sub(1, #toc_title) == toc_title
+            if use_dots then primePager(self) end
+            local result = original_init(self, ...)
+            if use_dots then refreshMenuDots(self) end
+            return result
+        end
+
+        function Menu:updateItems(...)
+            local result = original_update(self, ...)
+            if self._burrow_page_dots then refreshMenuDots(self) end
+            return result
+        end
+    end
 end
 
 -- Quick Settings is attached later by Burrow's loader. Once startup finishes,
--- layer the swipe guard over that finished TouchMenu wrapper. This preserves
--- slider dragging but prevents a swipe from being interpreted as a button tap.
+-- layer the swipe guard over that finished TouchMenu wrapper. Slider dragging
+-- remains available; other Quick Settings swipes are consumed safely.
 local UIManager = require("ui/uimanager")
 UIManager:nextTick(function()
     local QuickSettings = package.loaded["burrow.internal.2_quick_settings"]
@@ -39,9 +74,6 @@ local function cleanError(err)
     return tostring(err or "unknown error"):gsub("^.-:%d+:%s*", "")
 end
 
--- This is the final updater entrypoint. Resolve _prepareRelease at call time so
--- later preparation implementations cannot be bypassed by a cached function
--- reference from an earlier compatibility layer.
 function Updater:_performUpdate(release)
     local prepared, prepare_err = pcall(self._prepareRelease, self, release)
     if not prepared then

--- a/plugins/burrow.koplugin/burrow_updater_entry.lua
+++ b/plugins/burrow.koplugin/burrow_updater_entry.lua
@@ -18,6 +18,23 @@ if pager_ok and Pager and type(Pager.apply) == "function" then
     pcall(Pager.apply)
 end
 
+-- Quick Settings is attached later by Burrow's loader. Once startup finishes,
+-- layer the swipe guard over that finished TouchMenu wrapper. This preserves
+-- slider dragging but prevents a swipe from being interpreted as a button tap.
+local UIManager = require("ui/uimanager")
+UIManager:nextTick(function()
+    local QuickSettings = package.loaded["burrow.internal.2_quick_settings"]
+    if not (QuickSettings and QuickSettings.applied) then return end
+
+    local guard_ok, Guard = pcall(
+        dofile,
+        plugin_root .. "/internal_patches/2-quick-settings-swipe-guard.lua"
+    )
+    if guard_ok and Guard and type(Guard.apply) == "function" then
+        pcall(Guard.apply)
+    end
+end)
+
 local function cleanError(err)
     return tostring(err or "unknown error"):gsub("^.-:%d+:%s*", "")
 end

--- a/plugins/burrow.koplugin/burrow_version.lua
+++ b/plugins/burrow.koplugin/burrow_version.lua
@@ -1,6 +1,6 @@
 return {
-    VERSION = "0.4.2-beta.10",
-    DISPLAY_VERSION = "0.4.2-beta.10",
+    VERSION = "0.4.2-beta.11",
+    DISPLAY_VERSION = "0.4.2-beta.11",
     STORE_ENGINE_VERSION = "1.2.1",
 
     -- Burrow is tested against KOReader 2026.07.2. Older releases are blocked,

--- a/plugins/burrow.koplugin/internal_patches/2-quick-settings-swipe-guard.lua
+++ b/plugins/burrow.koplugin/internal_patches/2-quick-settings-swipe-guard.lua
@@ -1,0 +1,62 @@
+local MODULE_KEY = "burrow.internal.2_quick_settings_swipe_guard"
+local existing_module = package.loaded[MODULE_KEY]
+if existing_module then return existing_module end
+
+local Math = require("optmath")
+local TouchMenu = require("ui/widget/touchmenu")
+
+local Module = {
+    key = MODULE_KEY,
+    phase = "early",
+    filename = "2-quick-settings-swipe-guard.lua",
+}
+package.loaded[MODULE_KEY] = Module
+
+local function handleSliderGesture(touch_menu, ges)
+    local refs = touch_menu._rounded_qs_refs
+    if not refs or not ges or not ges.pos then return false end
+
+    for _, slider in ipairs(refs.sliders or {}) do
+        if slider.widget.dimen and ges.pos:intersectWith(slider.widget.dimen) then
+            local percentage = slider.widget:getPercentageFromPosition(ges.pos)
+            if percentage then
+                local state = slider.state
+                slider.setValue(Math.round(state.min + percentage * (state.max - state.min)))
+                return true
+            end
+        end
+    end
+
+    return false
+end
+
+function Module.apply()
+    if Module.applied then return true end
+    if TouchMenu._burrow_quick_settings_swipe_guard then
+        Module.applied = true
+        return true
+    end
+    TouchMenu._burrow_quick_settings_swipe_guard = true
+
+    -- 2-quick-settings.lua has already wrapped TouchMenu:onSwipe at this point.
+    -- Keep that implementation for normal KOReader tabs, but intercept Burrow's
+    -- custom Quick Settings panel first. A swipe must never act like a button tap.
+    local original_onSwipe = TouchMenu.onSwipe
+    function TouchMenu:onSwipe(arg, ges_ev)
+        if self._rounded_qs_refs and self.item_table and self.item_table.panel then
+            -- Slider dragging remains useful. Every other swipe in Quick Settings
+            -- is consumed so it cannot trigger an action tile or propagate into
+            -- TouchMenu while the gesture is still being processed.
+            handleSliderGesture(self, ges_ev)
+            return true
+        end
+        if original_onSwipe then
+            return original_onSwipe(self, arg, ges_ev)
+        end
+    end
+
+    Module.applied = true
+    return true
+end
+
+return Module


### PR DESCRIPTION
Promotes the device-tested beta.11 hotfixes to the prerelease branch only. Stable main remains unchanged.

What changed:
- prevents Quick Settings swipes from activating action tiles when a gesture ends over a button
- preserves frontlight and warmth slider dragging while consuming other Quick Settings swipes
- scopes the Home-style Menu pager behavior to Table of Contents instead of applying it to every KOReader Menu
- restores the Home and Store footer in Store
- bumps the prerelease version to 0.4.2-beta.11 and includes the full changelog

Root cause:
The existing Quick Settings swipe handler reused the tap gesture handler, so a swipe ending over an action tile could invoke that tile while KOReader was still processing the gesture. Separately, beta.10 reached Table of Contents by wrapping the base Menu class globally, which also altered Store and unrelated menus.

Validation:
- the Quick Settings behavior was device-tested by the user before publication
- the Store/TOC/Book Information pager behavior was device-tested before publication
- beta.11 keeps stable main untouched and is intended only for the prerelease branch
