### PR TITLE
Prepare Burrow 0.4.3-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to Burrow will be documented here.
 
 ## [Unreleased]
 
+## [0.4.3-beta.2] - 2026-08-13
+
+### Added
+
+- Added Bionic Reading as a persistent Reader Controls toggle for EPUB books
+- Added real bold fixation prefixes based on CrossPoint Focus Reading: 45% of each word, floored, with a 1-character minimum and 9-character maximum
+- Added cached shadow-EPUB rendering so Bionic Reading leaves the original EPUB untouched and continues using the currently selected font family
+- Added Search in Book compatibility across Bionic inline text-node boundaries
+- Added percentage and nearby semantic text anchoring to reduce reading-position jumps when Bionic Reading is toggled
+- Added last-used document-setting inheritance so the most recently established reader presentation follows into the next book
+- Added separate inherited profiles for reflowable `copt_*` settings and fixed-layout `kopt_*` settings, including the active reflowable font face/family mapping
+
+### Changed
+
+- Kept Bionic Reading as a fixed Reader Controls action rather than another configurable Reader button or Burrow Settings entry
+- Reader document settings now follow the latest established presentation while reading position, progress, bookmarks, highlights, annotations, search history, reading status, stylesheet selection, and typography-language data remain book-specific
+
+### Fixed
+
+- Prevented Bionic Reading initialization failures from quarantining the entire Quick Settings feature
+- Preserved Search in Book behavior while Bionic Reading splits words across bold/regular inline nodes
+- Prevented Bionic toggles from falling back to the beginning of the book when an XPointer from the normal DOM does not resolve cleanly against the Bionic shadow DOM
+
+### Known limitation
+
+- Toggling Bionic Reading can still occasionally move a few pages because real bold changes line wrapping and pagination; Burrow uses a nearby semantic text anchor with percentage fallback to keep the reader close to the same text
+
+## [0.4.3-beta.1] - 2026-08-13
+
+### Changed
+
+- Reader Controls now opens Burrow Quick Settings as a standalone top panel instead of automatically opening KOReader's bottom Text/Config panel underneath it
+
+### Fixed
+
+- Made the Text Reader Controls action close the top reader menu through KOReader's own ReaderMenu controller and open or reuse exactly one ReaderConfig dialog
+- Preserved KOReader's normal reader-menu behavior when Burrow Quick Settings is not configured to open first
+
 ## [0.4.2] - 2026-08-13
 
 ### Added
@@ -35,263 +73,4 @@ All notable changes to Burrow will be documented here.
 
 ### Fixed
 
-- Prevented Quick Settings swipes from activating action tiles when a swipe ends over a button
-- Kept frontlight and warmth slider dragging functional while consuming other Quick Settings swipes
-- Scoped the Home-style Menu pager replacement to Table of Contents instead of modifying every KOReader Menu
-- Restored the Home and Store footer while browsing Store after the beta.10 pager regression
-- Prevented the beta.10 pager customization from interfering with unrelated KOReader menus
-
-## [0.4.2-beta.10] - 2026-08-13
-
-### Changed
-
-- Replaced the Quick Settings Restart glyph with a power-style icon so Restart is visually distinct from Rotate
-- Replaced the older arrow-based paged-dialog footers with Burrow's Home-style page indicator: a long active pill with small inactive dots
-- Centered the Table of Contents page indicator at the bottom of the screen to match the Home library pager
-
-### Fixed
-
-- Restored four-way Quick Settings rotation so Rotate cycles through all four physical screen orientations
-- Restored rotation persistence between the library and reader
-- Persisted the selected orientation across a full KOReader restart by saving and explicitly restoring the File Manager rotation while rotation locking is enabled
-- Restored grid minimums down to one row or one column, allowing layouts such as 2x1, 1x3, and other rectangular combinations while retaining the 8x8 maximum
-- Improved automatic update checks so enabling Automatic update checks can immediately run a due check
-- Improved automatic update checks when KOReader starts offline by checking again after network connectivity becomes available
-- Kept automatic update checks on their recurring schedule while KOReader remains open
-- Added retry scheduling after failed automatic checks without allowing checks to run more frequently than hourly
-- Updated Book Information pagination to use the Home-style swipe-and-dots interface
-- Updated Table of Contents pagination to use the Home-style swipe-and-dots interface
-
-## [0.4.2-beta.9] - 2026-08-13
-
-### Changed
-
-- Promoted the updater, rotation, and grid recovery work to the prerelease channel for device testing
-
-### Fixed
-
-- Restored four-way Quick Settings rotation
-- Restored remembered rotation between File Manager and Reader
-- Restored one-row and one-column grid configurations
-- Improved automatic update-check triggering for the beta update channel
-
-## [0.4.1] - 2026-08-12
-
-### Changed
-
-- Centered the logo-only Burrow badger vertically in the header space above the hero card
-- Added a Burrow-scoped Home icon with optically normalized stroke weight while keeping the original toolbar icons and touch-target spacing
-
-### Fixed
-
-- Prevented automatic-series and physical-folder borders from appearing as bright outlines in KOReader night mode
-
-## [0.4.0] - 2026-08-12
-
-### Added
-
-- Added a cleaned-up Burrow Settings structure organized around Library, Navigation, Quick Settings, Store, Advanced, and About
-- Added independent controls for book, physical-folder, and series titles under covers
-- Added a Return to Library display option independent of automatic series grouping
-
-### Changed
-
-- Promoted Burrow out of beta as the first stable release
-- Moved automatic series grouping out of KOReader's stock File Browser settings and into Burrow Settings
-- Consolidated Quick Settings configuration under Burrow Settings
-- Unified book, physical-folder, and virtual-series cover geometry so all three use the same sizing policy
-- Kept cover size and spacing controls available from the cleaned-up Library settings
-- Reordered the cover rendering modules so rounded book geometry is established before automatic series processing and final scaling
-
-### Fixed
-
-- Kept Return to Library available for manually organized folders when automatic series grouping is disabled
-- Prevented titles from intersecting enlarged covers
-- Prevented physical-folder rendering from discarding the configured cover size
-- Corrected rebuilt cover tiles so the configured size is reapplied after reader returns and browser refreshes
-- Replaced heuristic physical-folder cover discovery with explicit cover references in the final layout pass
-
-## [0.3.8-beta] - 2026-08-06
-
-### Changed
-
-- Unified the Home and Store footer dimensions so the navigation remains the same size when switching screens
-- Made the Store respect the configured Home and Store label-size setting
-- Standardized the active-tab underline width across Home and Store
-
-## [0.3.7-beta] - 2026-08-05
-
-### Changed
-
-- Improved Store cover loading and short-term catalog caching
-- Reduced unnecessary cover-cache pruning and network requests
-- Refined the Home and Store footer spacing and active underline
-
-### Fixed
-
-- Hid the return arrow while the Burrow Home and Store footer is active
-- Hid page indicators on single-page Store menus
-- Increased spacing between the Burrow icon and the first row of Store covers
-- Repaired and compacted the Store download queue at startup
-- Prevented duplicate queued downloads and removed completed direct downloads from the queue
-- Persisted cleared download queues immediately
-
-## [0.3.6-beta] - 2026-08-05
-
-### Added
-
-- Extended the Home and Store footer to nested manual folders inside the configured library
-
-### Changed
-
-- Promoted the device-tested 0.3.6 build to public beta
-
-### Fixed
-
-- Anchored the folder and collection marker to the upper-left corner of the cover
-- Applied real rounded-corner masking to manual-folder artwork in Cover Grid and Cover List
-
-## [0.3.5-beta] - 2026-08-05
-
-### Added
-
-- Added the stacked-books series marker to physical folders and collection-style directory tiles in Cover Grid
-- Added the Burrow Return to Library icon to the corresponding Cover List row
-
-## [0.3.4-beta] - 2026-08-05
-
-### Fixed
-
-- Stopped the physical-folder consistency layer from rebuilding automatic-series tiles
-- Removed duplicated automatic-series covers and doubled series captions
-- Reduced physical-folder covers to the same caption-reserved height used by normal book covers
-- Kept automatic-series Cover Grid rendering on its native Burrow path while retaining rounded full-size folder artwork in Cover List
-
-## [0.3.3-beta] - 2026-08-05
-
-### Fixed
-
-- Prevented legacy ProjectTitle and generated folder-cover cache paths from being treated as custom folder images
-- Physical folders now use only a real folder-local cover image or the first available book cover
-- Published the folder fix under a new version so users do not receive a cached 0.3.2 package
-
-## [0.3.2-beta] - 2026-08-05
-
-### Added
-
-- Added a Burrow setting to show or hide numbered series badges on book covers
-
-### Changed
-
-- Made physical folders and automatic-series folders use the same cover presentation
-- Physical folders now use a custom folder cover when available, otherwise the first available book cover
-- Removed the multi-cover mosaic fallback from folder tiles
-
-### Fixed
-
-- Reworked Cover List folder styling so full-size rounded covers are applied during every row build
-- Prevented folder-name overlays and item-count circles from being redrawn over unified Cover Grid tiles
-
-## [0.3.1-beta] - 2026-08-05
-
-### Fixed
-
-- Made folder and automatic-series artwork use the full available cover size in Cover List
-- Applied the same rounded frame to folder and series artwork used for book covers in Cover List
-
-## [0.3.0-beta] - 2026-08-05
-
-### Added
-
-- Public beta documentation and device screenshots
-- Beta notes covering current compatibility and testing limits
-
-### Changed
-
-- Promoted Burrow from alpha to public beta
-- Updated the last-tested KOReader version to 2026.07.2
-
-### Fixed
-
-- Capitalized the Reading Controls and Quick Settings panel titles
-
-## [0.2.2-alpha] - 2026-08-05
-
-### Fixed
-
-- Made cover-size values above 100% render at the requested scale instead of being capped by the original tile dimensions
-- Corrected the capitalization of the Reading Controls heading
-
-## [0.2.1-alpha] - 2026-08-05
-
-### Added
-
-- Flexible KOReader compatibility policy with minimum and last-tested versions
-- Dependency-aware degraded mode for optional feature groups
-- Module status reporting and quarantined-feature retry controls
-- Guarded `burrow_library.lua` core runtime
-
-### Changed
-
-- Removed the exact KOReader version lock
-- Reduced `main.lua` to prerequisite checks, loader setup, and plugin-class creation
-- Moved the core library runtime into a guarded module
-
-### Fixed
-
-- Prevented one optional module failure from disabling unrelated Burrow features
-- Prevented repeated sourcing from wrapping KOReader methods more than once
-
-## [0.2.0-alpha] - 2026-08-05
-
-### Changed
-
-- Converted Burrow into a self-contained KOReader plugin
-- Added a phased, plugin-owned module loader
-
-## [0.1.9-alpha] - 2026-08-05
-
-### Fixed
-
-- Rebuilt the return-to-library tile with a fresh, uncached icon widget after leaving the reader
-- Prevented stale reader pixels from appearing through the return icon
-
-## [0.1.4-alpha] - 2026-08-05
-
-### Fixed
-
-- Restored access to the Store download queue
-- Excluded JPEG and other cover-image links from book download choices
-
-## [0.1.3-alpha] - 2026-08-04
-
-### Changed
-
-- Consolidated the library and Store under Burrow-owned names
-- Added one-time migration for compatible earlier settings and databases
-
-## [0.1.0-alpha] - 2026-08-04
-
-### Added
-
-- Initial unified Burrow library, Store, and reader-interface package
-
-[Unreleased]: https://github.com/richbeatty/burrow.koplugin/compare/v0.4.2...HEAD
-[0.4.2]: https://github.com/richbeatty/burrow.koplugin/releases/tag/v0.4.2
-[0.4.2-beta.11]: https://github.com/richbeatty/burrow.koplugin/releases/tag/v0.4.2-beta.11
-[0.4.2-beta.10]: https://github.com/richbeatty/burrow.koplugin/releases/tag/v0.4.2-beta.10
-[0.4.2-beta.9]: https://github.com/richbeatty/burrow.koplugin/releases/tag/v0.4.2-beta.9
-[0.4.1]: https://github.com/richbeatty/burrow.koplugin/releases/tag/v0.4.1
-[0.4.0]: https://github.com/richbeatty/burrow.koplugin/releases/tag/v0.4.0
-[0.3.8-beta]: https://github.com/richbeatty/burrow.koplugin/releases/tag/v0.3.8-beta
-[0.3.7-beta]: https://github.com/richbeatty/burrow.koplugin/releases/tag/v0.3.7-beta
-[0.3.6-beta]: https://github.com/richbeatty/burrow.koplugin/releases/tag/v0.3.6-beta
-[0.3.5-beta]: https://github.com/richbeatty/burrow.koplugin/releases/tag/v0.3.5-beta
-[0.3.4-beta]: https://github.com/richbeatty/burrow.koplugin/releases/tag/v0.3.4-beta
-[0.3.3-beta]: https://github.com/richbeatty/burrow.koplugin/releases/tag/v0.3.3-beta
-[0.3.2-beta]: https://github.com/richbeatty/burrow.koplugin/releases/tag/v0.3.2-beta
-[0.3.1-beta]: https://github.com/richbeatty/burrow.koplugin/releases/tag/v0.3.1-beta
-[0.3.0-beta]: https://github.com/richbeatty/burrow.koplugin/releases/tag/v0.3.0-beta
-[0.2.2-alpha]: https://github.com/richbeatty/burrow.koplugin/releases/tag/v0.2.2-alpha
-[0.2.1-alpha]: https://github.com/richbeatty/burrow.koplugin/releases/tag/v0.2.1-alpha
-[0.2.0-alpha]: https://github.com/richbeatty/burrow.koplugin/releases/tag/v0.2.0-alpha
+- Prevented Quick Settings swipes from activating action tiles when a swipe ends over a button‹HÙ\œ›ÛYÚ[™Ø\›]ÛY\ˆ˜YÙÚ[™È[˜İ[Û˜[Ú[HÛÛœİ[Z[™Èİ\ˆ]ZXÚÈÙ][™ÜÈİÚ\\Â‹HØÛÜYHÛYK\İ[HY[HYÙ\ˆ™\XÙ[Y[ÈX›HÙˆÛÛ[È[œİXYÙˆ[ÙYZ[™È]™\HÓÔ™XY\ˆY[B‹H™\İÜ™YHÛYH[™İÜ™H›Ûİ\ˆÚ[Hœ›İÜÚ[™ÈİÜ™HY\ˆH™]KŒLYÙ\ˆ™YÜ™\ÜÚ[Û‚‹H™]™[YH™]KŒLYÙ\ˆİ\İÛZ^˜][Ûˆœ›ÛH[\™™\š[™ÈÚ][œ™[]YÓÔ™XY\ˆY[\Â‚ˆÈÈÌŒ‹X™]KŒLHHŒ‹LLLÂ‚ˆÈÈÈÚ[™ÙY‚‹H™\XÙYH]ZXÚÈÙ][™ÜÈ™\İ\Û\Ú]HİÙ\‹\İ[HXÛÛˆÛÈ™\İ\\Èš\İX[H\İ[˜İœ›ÛH›İ]B‹H™\XÙYHÛ\ˆ\œ›İËX˜\ÙYYÙYYX[ÙÈ›Ûİ\œÈÚ]\œ›İÉÜÈÛYK\İ[HYÙH[™XØ]ÜˆHÛ™ÈXİ]™H[Ú]ÛX[[˜Xİ]™HİÂ‹HÙ[\™YHX›HÙˆÛÛ[ÈYÙH[™XØ]Üˆ]H›İÛHÙˆHØÜ™Y[ˆÈX]ÚHÛYHXœ˜\HYÙ\‚‚ˆÈÈÈš^Y‚‹H™\İÜ™Y›İ\‹]Ø^H]ZXÚÈÙ][™ÜÈ›İ][ÛˆÛÈ›İ]HŞXÛ\È›İYÚ[›İ\ˆ\ÚXØ[ØÜ™Y[ˆÜšY[][ÛœÂ‹H™\İÜ™Y›İ][Ûˆ\œÚ\İ[˜ÙH™]ÙY[ˆHXœ˜\H[™™XY\‚‹H\œÚ\İYHÙ[XİYÜšY[][ÛˆXÜ›ÜÜÈH[ÓÔ™XY\ˆ™\İ\HØ]š[™È[™^XÚ]H™\İÜš[™ÈHš[HX[˜YÙ\ˆ›İ][ÛˆÚ[H›İ][ÛˆØÚÚ[™È\È[˜X›Y‹H™\İÜ™YÜšYZ[š[][\ÈİÛˆÈÛ™H›İÈÜˆÛ™HÛÛ[[‹[İÚ[™È^[İ]ÈİXÚ\ÈK^Ë[™İ\ˆ™Xİ[™İ[\ˆÛÛXš[˜][ÛœÈÚ[H™]Z[š[™ÈHX^[][B‹H[\›İ™Y]]ÛX]XÈ\]HÚXÚÜÈÛÈ[˜X›[™È]]ÛX]XÈ\]HÚXÚÜÈØ[ˆ[[YYX][H[ˆHYHÚXÚÂ‹H[\›İ™Y]]ÛX]XÈ\]HÚXÚÜÈÚ[ˆÓÔ™XY\ˆİ\ÈÙ™›[™HHÚXÚÚ[™ÈYØZ[ˆY\ˆ™]ÛÜšÈÛÛ›™Xİ]š]H™XÛÛY\È]˜Z[X›B‹HÙ\]]ÛX]XÈ\]HÚXÚÜÈÛˆZ\ˆ™Xİ\œš[™ÈØÚY[HÚ[HÓÔ™XY\ˆ™[XZ[œÈÜ[‚‹HYY™]HØÚY[[™ÈY\ˆ˜Z[Y]]ÛX]XÈÚXÚÜÈÚ]İ][İÚ[™ÈÚXÚÜÈÈ[ˆ[Ü™Hœ™\]Y[H[ˆİ\›B‹H\]Y›ÛÚÈ[™›Ü›X][ÛˆYÚ[˜][ÛˆÈ\ÙHHÛYK\İ[HİÚ\KX[™YİÈ[\™˜XÙB‹H\]YX›HÙˆÛÛ[ÈYÚ[˜][ÛˆÈ\ÙHHÛYK\İ[HİÚ\KX[™YİÈ[\™˜XÙB‚ˆÈÈÌŒ‹X™]KWHHŒ‹LLLÂ‚ˆÈÈÈÚ[™ÙY‚‹H›Û[İYH\]\‹›İ][Û‹[™ÜšY™XÛİ™\HÛÜšÈÈH™\™[X\ÙHÚ[›™[›Üˆ]šXÙH\İ[™Â‚ˆÈÈÈš^Y‚‹H™\İÜ™Y›İ\‹]Ø^H]ZXÚÈÙ][™ÜÈ›İ][Û‚‹H™\İÜ™Y™[Y[X™\™Y›İ][Ûˆ™]ÙY[ˆš[HX[˜YÙ\ˆ[™™XY\‚‹H™\İÜ™YÛ™K\›İÈ[™Û™KXÛÛ[[ˆÜšYÛÛ™šYİ\˜][ÛœÂ‹H[\›İ™Y]]ÛX]XÈ\]KXÚXÚÈšYÙÙ\š[™È›ÜˆH™]H\]HÚ[›™[‚ˆÈÈÌŒWHHŒ‹LLL‚‚ˆÈÈÈÚ[™ÙY‚‹HÙ[\™YHÙÛË[Û›H\œ›İÈ˜YÙ\ˆ™\XØ[H[ˆHXY\ˆÜXÙHX›İ™HH\›ÈØ\™‹HYYH\œ›İË\ØÛÜYÛYHXÛÛˆÚ]ÜXØ[H›Ü›X[^™Yİ›ÚÙHÙZYÚÚ[HÙY\[™ÈHÜšYÚ[˜[ÛÛ˜\ˆXÛÛœÈ[™İXÚ]\™Ù]ÜXÚ[™Â‚ˆÈÈÈš^Y‚‹H™]™[Y]]ÛX]XË\Ù\šY\È[™\ÚXØ[Y›Û\ˆ›Ü™\œÈœ›ÛH\X\š[™È\ÈœšYÚİ][™\È[ˆÓÔ™XY\ˆšYÚ[ÙB‚ˆÈÈÌŒHHŒ‹LLL‚‚ˆÈÈÈYY‚‹HYYHÛX[™Y]B'W'&÷r6WGF–æw27G'V7GW&R÷&væ—¦VB&÷VæBÆ–'&'’Âæf–vF–öâÂV–6²6WGF–æw2Â7F÷&RÂGfæ6VBÂæB&÷W@¢ÒFFVB–æFWVæFVçB6öçG&öÇ2f÷"&öö²Â‡—6–6ÂÖföÆFW"ÂæB6W&–W2F—FÆW2VæFW"6÷fW'0¢ÒFFVB&WGW&âFòÆ–'&'’F—7Æ’÷F–öâ–æFWVæFVçBöbWFöÖF–26W&–W2w&÷W–æp ¢2226†ævV@ ¢Ò&öÖ÷FVB'W'&÷r÷WBöb&WF2F†Rf—'7B7F&ÆR&VÆV6P¢ÒÖ÷fVBWFöÖF–26W&–W2w&÷W–ær÷WBöb´õ&VFW"w27Fö6²f–ÆR'&÷w6W"6WGF–æw2æB–çFò'W'&÷r6WGF–æw0¢Ò6öç6öÆ–FFVBV–6²6WGF–æw26öæf–wW&F–öâVæFW"'W'&÷r6WGF–æw0¢ÒVæ–f–VB&öö²Â‡—6–6ÂÖföÆFW"ÂæBf—'GVÂ×6W&–W26÷fW"vVöÖWG'’6òÆÂF‡&VRW6RF†R6ÖR6—¦–æröÆ–7¢Ò¶WB6÷fW"6—¦RæB76–ær6öçG&öÇ2f–Æ&ÆRg&öÒF†R6ÆVæVB×WÆ–'&'’6WGF–æw0¢Ò&V÷&FW&VBF†R6÷fW"&VæFW&–ærÖöGVÆW26ò&÷VæFVB&öö²vVöÖWG'’—2W7F&Æ—6†VB&Vf÷&RWFöÖF–26W&–W2&ö6W76–æræBf–æÂ66Æ–æp ¢222f—†V@ ¢Ò¶WB&WGW&âFòÆ–'&'’f–Æ&ÆRf÷"ÖçVÆÇ’÷&væ—¦VBföÆFW'2v†VâWFöÖF–26W&–W2w&÷W–ær—2F—6&ÆV@¢Ò&WfVçFVBF—FÆW2g&öÒ–çFW'6V7F–ærVæÆ&vVB6÷fW'0¢Ò&WfVçFVB‡—6–6ÂÖföÆFW"&VæFW&–ærg&öÒF—66&F–ærF†R6öæf–wW&VB6÷fW"6—¦P¢Ò6÷'&V7FVB&V'V–ÇB6÷fW"F–ÆW26òF†R6öæf–wW&VB6—¦R—2&VÆ–VBgFW"&VFW"&WGW&ç2æB'&÷w6W"&Vg&W6†W0¢Ò&WÆ6VB†WW&—7F–2‡—6–6ÂÖföÆFW"6÷fW"F—66÷fW'’v—F‚W‡Æ–6—B6÷fW"&VfW&Væ6W2–âF†Rf–æÂÆ–÷WB70 ¢22³ã2ã‚Ö&WFÒÒ##bÓ‚Ó` ¢2226†ævV@ ¢ÒVæ–f–VBF†R†öÖRæB7F÷&Rfö÷FW"F–ÖVç6–öç26òF†Ræf–vF–öâ&VÖ–ç2F†R6ÖR6—¦Rv†Vâ7v—F6†–ær67&VVç0¢ÒÖFRF†R7F÷&R&W7V7BF†R6öæf–wW&VB†öÖRæB7F÷&RÆ&VÂ×6—¦R6WGF–æp¢Ò7FæF&F—¦VBF†R7F—fR×F"VæFW&Æ–æRv–GF‚7&÷72†öÖRæB7F÷&P ¢22³ã2ãrÖ&WFÒÒ##bÓ‚ÓP ¢2226†ævV@ ¢Ò–×&÷fVB7F÷&R6÷fW"ÆöF–æræB6†÷'B×FW&Ò6FÆör66†–æp¢Ò&VGV6VBVææV6W76'’6÷fW"Ö66†R'Væ–æræBæWGv÷&²&WVW7G0¢Ò&Vf–æVBF†R†öÖRæB7F÷&Rfö÷FW"76–æræB7F—fRVæFW&Æ–æP ¢222f—†V@ ¢Ò†–BF†R&WGW&â'&÷rv†–ÆRF†R'W'&÷r†öÖRæB7F÷&Rfö÷FW"—27F—fP¢Ò†–BvR–æF–6F÷'2öâ6–ævÆR×vR7F÷&RÖVçW0¢Ò–æ7&V6VB76–ær&WGvVVâF†R'W'&÷r–6öâæBF†Rf—'7B&÷röb7F÷&R6÷fW'0¢Ò&W—&VBæB6ö×7FVBF†R7F÷&RF÷væÆöBVWVRB7F'GW ¢Ò&WfVçFVBGWÆ–6FRVWVVBF÷væÆöG2æB&VÖ÷fVB6ö×ÆWFVBF—&V7BF÷væÆöG2g&öÒF†RVWVP¢ÒW'6—7FVB6ÆV&VBF÷væÆöBVWVW2–ÖÖVF–FVÇ ¢22³ã2ãbÖ&WFÒÒ##bÓ‚ÓP ¢222FFV@ ¢ÒW‡FVæFVBF†R†öÖRæB7F÷&Rfö÷FW"FòæW7FVBÖçVÂföÆFW'2–ç6–FRF†R6öæf–wW&VBÆ–'&' ¢2226†ævV@ ¢Ò&öÖ÷FVBF†RFWf–6R×FW7FVBã2ãb'V–ÆBFòV&Æ–2&WF ¢222f—†V@ ¢Òæ6†÷&VBF†RföÆFW"æB6öÆÆV7F–öâÖ&¶W"FòF†RWW"ÖÆVgB6÷&æW"öbF†R6÷fW ¢ÒÆ–VB&VÂ&÷VæFVBÖ6÷&æW"Ö6¶–ærFòÖçVÂÖföÆFW"'Gv÷&²–â6÷fW"w&–BæB6÷fW"Æ—7@ ¢22³ã2ãRÖ&WFÒÒ##bÓ‚ÓP ¢222FFV@ ¢ÒFFVBF†R7F6¶VBÖ&öö·26W&–W2Ö&¶W"Fò‡—6–6ÂföÆFW'2æB6öÆÆV7F–öâ×7G–ÆRF—&V7F÷'’F–ÆW2–â6÷fW"w&–@¢ÒFFVBF†R'W'&÷r&WGW&âFòÆ–'&'’–6öâFòF†R6÷'&W7öæF–ær6÷fW"Æ—7B&÷p ¢22³ã2ãBÖ&WFÒÒ##bÓ‚ÓP ¢222f—†V@ ¢Ò7F÷VBF†R‡—6–6ÂÖföÆFW"6öç6—7FVæ7’Æ–W"g&öÒ&V'V–ÆF–ærWFöÖF–2×6W&–W2F–ÆW0¢Ò&VÖ÷fVBGWÆ–6FVBWFöÖF–2×6W&–W26÷fW'2æBF÷V&ÆVB6W&–W26F–öç0¢Ò&VGV6VB‡—6–6ÂÖföÆFW"6÷fW'2FòF†R6ÖR6F–öâ×&W6W'fVB†V–v‡BW6VB'’æ÷&ÖÂ&öö²6÷fW'0¢Ò¶WBWFöÖF–2×6W&–W26÷fW"w&–B&VæFW&–æröâ—G2æF—fR'W'&÷rF‚v†–ÆR&WF–æ–ær&÷VæFVBgVÆÂ×6—¦RföÆFW"'Gv÷&²–â6÷fW"Æ—7@ ¢22³ã2ã2Ö&WFÒÒ##bÓ‚ÓP ¢222f—†V@ ¢Ò&WfVçFVBÆVv7’&ö¦V7EF—FÆRæBvVæW&FVBföÆFW"Ö6÷fW"66†RF‡2g&öÒ&V–ærG&VFVB27W7FöÒföÆFW"–ÖvW0¢Ò‡—6–6ÂföÆFW'2æ÷rW6RöæÇ’&VÂföÆFW"ÖÆö6Â6÷fW"–ÖvR÷"F†Rf—'7Bf–Æ&ÆR&öö²6÷fW ¢ÒV&Æ—6†VBF†RföÆFW"f—‚VæFW"æWrfW'6–öâ6òW6W'2Fòæ÷B&V6V—fR66†VBã2ã"6¶vP ¢22³ã2ã"Ö&WFÒÒ##bÓ‚ÓP ¢222FFV@ ¢ÒFFVB'W'&÷r6WGF–ærFò6†÷r÷"†–FRçVÖ&W&VB6W&–W2&FvW2öâ&öö²6÷fW'0 ¢2226†ævV@ ¢ÒÖFR‡—6–6ÂföÆFW'2æBWFöÖF–2×6W&–W2föÆFW'2W6RF†R6ÖR6÷fW"&W6VçFF–öà¢Ò‡—6–6ÂföÆFW'2æ÷rW6R7W7FöÒföÆFW"6÷fW"v†Vâf–Æ&ÆRÂ÷F†W'v—6RF†Rf—'7Bf–Æ&ÆR&öö²6÷fW ¢Ò&VÖ÷fVBF†R×VÇF’Ö6÷fW"Ö÷6–2fÆÆ&6²g&öÒföÆFW"F–ÆW0 ¢222f—†V@ ¢Ò&Wv÷&¶VB6÷fW"Æ—7BföÆFW"7G–Æ–ær6ògVÆÂ×6—¦R&÷VæFVB6÷fW'2&RÆ–VBGW&–ærWfW'’&÷r'V–Æ@¢Ò&WfVçFVBföÆFW"ÖæÖR÷fW&Æ—2æB—FVÒÖ6÷VçB6—&6ÆW2g&öÒ&V–ær&VG&vâ÷fW"Væ–f–VB6÷fW"w&–BF–ÆW0 ¢22³ã2ãÖ&WFÒÒ##bÓ‚ÓP ¢222f—†V@ ¢ÒÖFRföÆFW"æBWFöÖF–2×6W&–W2'Gv÷&²W6RF†RgVÆÂf–Æ&ÆR6÷fW"6—¦R–â6÷fW"Æ—7@¢ÒÆ–VBF†R6ÖR&÷VæFVBg&ÖRFòföÆFW"æB6W&–W2'Gv÷&²W6VBf÷"&öö²6÷fW'2–â6÷fW"Æ—7@ ¢22³ã2ãÖ&WFÒÒ##bÓ‚ÓP ¢222FFV@ ¢ÒV&Æ–2&WFFö7VÖVçFF–öâæBFWf–6R67&VVç6†÷G0¢Ò&WFæ÷FW26÷fW&–ær7W'&VçB6ö×F–&–Æ—G’æBFW7F–ærÆ–Ö—G0 ¢2226†ævV@ ¢Ò&öÖ÷FVB'W'&÷rg&öÒÇ†FòV&Æ–2&WF¢ÒWFFVBF†RÆ7B×FW7FVB´õ&VFW"fW'6–öâFò##bãrã  ¢222f—†V@ ¢Ò6—FÆ—¦VBF†R&VF–ær6öçG&öÇ2æBV–6²6WGF–æw2æVÂF—FÆW0 ¢22³ã"ã"ÖÇ†ÒÒ##bÓ‚ÓP ¢222f—†V@ ¢ÒÖFR6÷fW"×6—¦RfÇVW2&÷fRR&VæFW"BF†R&WVW7FVB66ÆR–ç7FVBöb&V–ær6VB'’F†R÷&–v–æÂF–ÆRF–ÖVç6–öç0¢Ò6÷'&V7FVBF†R6—FÆ—¦F–öâöbF†R&VF–ær6öçG&öÇ2†VF–æp ¢22³ã"ãÖÇ†ÒÒ##bÓ‚ÓP ¢222FFV@ ¢ÒfÆW†–&ÆR´õ&VFW"6ö×F–&–Æ—G’öÆ–7’v—F‚Ö–æ–×VÒæBÆ7B×FW7FVBfW'6–öç0¢ÒFWVæFVæ7’Öv&RFVw&FVBÖöFRf÷"÷F–öæÂfVGW&Rw&÷W0¢ÒÖöGVÆR7FGW2&W÷'F–æræBV&çF–æVBÖfVGW&R&WG'’6öçG&öÇ0¢ÒwV&FVB'W'&÷uöÆ–'&'’æÇV6÷&R'VçF–ÖP ¢2226†ævV@ ¢Ò&VÖ÷fVBF†RW†7B´õ&VFW"fW'6–öâÆö6°¢Ò&VGV6VBÖ–âæÇVFò&W&WV—6—FR6†V6·2ÂÆöFW"6WGWÂæBÇVv–âÖ6Æ727&VF–öà¢ÒÖ÷fVBF†R6÷&RÆ–'&'’'VçF–ÖR–çFòwV&FVBÖöGVÆP ¢222f—†V@ ¢Ò&WfVçFVBöæR÷F–öæÂÖöGVÆRf–ÇW&Rg&öÒF—6&Æ–ærVç&VÆFVB'W'&÷rfVGW&W0¢Ò&WfVçFVB&WVFVB6÷W&6–ærg&öÒw&–ær´õ&VFW"ÖWF†öG2Ö÷&RF†âöæ6P ¢22³ã"ãÖÇ†ÒÒ##bÓ‚ÓP ¢2226†ævV@ ¢Ò6öçfW'FVB'W'&÷r–çFò6VÆbÖ6öçF–æVB´õ&VFW"ÇVv–à¢ÒFFVB†6VBÂÇVv–âÖ÷væVBÖöGVÆRÆöFW  ¢22³ãã’ÖÇ†ÒÒ##bÓ‚ÓP ¢222f—†V@ ¢Ò&V'V–ÇBF†R&WGW&â×FòÖÆ–'&'’F–ÆRv—F‚g&W6‚ÂVæ66†VB–6öâv–FvWBgFW"ÆVf–ærF†R&VFW ¢Ò&WfVçFVB7FÆR&VFW"—†VÇ2g&öÒV&–ærF‡&÷Vv‚F†R&WGW&â–6öà ¢22³ããBÖÇ†ÒÒ##bÓ‚ÓP ¢222f—†V@ ¢Ò&W7F÷&VB66W72FòF†R7F÷&RF÷væÆöBVWVP¢ÒW†6ÇVFVB¥TræB÷F†W"6÷fW"Ö–ÖvRÆ–æ·2g&öÒ&öö²F÷væÆöB6†ö–6W0 ¢22³ãã2ÖÇ†ÒÒ##bÓ‚Ó@ ¢2226†ævV@ ¢Ò6öç6öÆ–FFVBF†RÆ–'&'’æB7F÷&RVæFW"'W'&÷rÖ÷væVBæÖW0¢ÒFFVBöæR×F–ÖRÖ–w&F–öâf÷"6ö×F–&ÆRV&Æ–W"6WGF–æw2æBFF&6W0 ¢22³ããÖÇ†ÒÒ##bÓ‚Ó@ ¢222FFV@ ¢Ò–æ—F–ÂVæ–f–VB'W'&÷rÆ–'&'’Â7F÷&RÂæB&VFW"Ö–çFW&f6R6¶vP ¥µVç&VÆV6VEÓ¢‡GG3¢òöv—F‡V"æ6öÒ÷&–6†&VGG’ö'W'&÷ræ¶÷ÇVv–âö6ö×&R÷cãBã2Ö&WFã"ââä„T@¥³ãBã2Ö&WFã%Ó¢‡GG3¢òöv—F‡V"æ6öÒ÷&–6†&VGG’ö'W'&÷ræ¶÷ÇVv–â÷&VÆV6W2÷Fr÷cãBã2Ö&WFã ¥³ãBã2Ö&WFãÓ¢‡GG3¢òöv—F‡V"æ6öÒ÷&–6†&VGG’ö'W'&÷ræ¶÷ÇVv–â÷&VÆV6W2÷Fr÷cãBã2Ö&WFã¥³ãBã%Ó¢‡GG3¢òöv—F‡V"æ6öÒ÷&–6†&VGG’ö'W'&÷ræ¶÷ÇVv–â÷&VÆV6W2÷Fr÷cãBã ¥³ãBã"Ö&WFãÓ¢‡GG3¢òöv—F‡V"æ6öÒ÷&–6†&VGG’ö'W'&÷ræ¶÷ÇVv–â÷&VÆV6W2÷Fr÷cãBã"Ö&WFã¥³ãBã"Ö&WFãÓ¢‡GG3¢òöv—F‡V"æ6öÒ÷&–6†&VGG’ö'W'&÷ræ¶÷ÇVv–â÷&VÆV6W2÷Fr÷cãBã"Ö&WFã ¥³ãBã"Ö&WFã•Ó¢‡GG3¢òöv—F‡V"æ6öÒ÷&–6†&VGG’ö'W'&÷ræ¶÷ÇVv–â÷&VÆV6W2÷Fr÷cãBã"Ö&WFã¥³ãBãÓ¢‡GG3¢òöv—F‡V"æ6öÒ÷&–6†&VGG’ö'W'&÷ræ¶÷ÇVv–â÷&VÆV6W2÷Fr÷cãBã¥³ãBãÓ¢‡GG3¢òöv—F‡V"æ6öÒ÷&–6†&VGG’ö'W'&÷ræ¶÷ÇVv–â÷&VÆV6W2÷Fr÷cãBã ¥³ã2ã‚Ö&WFÓ¢‡GG3¢òöv—F‡V"æ6öÒ÷&–6†&VGG’ö'W'&÷ræ¶÷ÇVv–â÷&VÆV6W2÷Fr÷cã2ã‚Ö&WF¥³ã2ãrÖ&WFÓ¢‡GG3¢òöv—F‡V"æ6öÒ÷&–6†&VGG’ö'W'&÷ræ¶÷ÇVv–â÷&VÆV6W2÷Fr÷cã2ãrÖ&WF¥³ã2ãbÖ&WFÓ¢‡GG3¢òöv—F‡V"æ6öÒ÷&–6†&VGG’ö'W'&÷ræ¶÷ÇVv–â÷&VÆV6W2÷Fr÷cã2ãbÖ&WF¥³ã2ãRÖ&WFÓ¢‡GG3¢òöv—F‡V"æ6öÒ÷&–6†&VGG’ö'W'&÷ræ¶÷ÇVv–â÷&VÆV6W2÷Fr÷cã2ãRÖ&WF¥³ã2ãBÖ&WFÓ¢‡GG3¢òöv—F‡V"æ6öÒ÷&–6†&VGG’ö'W'&÷ræ¶÷ÇVv–â÷&VÆV6W2÷Fr÷cã2ãBÖ&WF¥³ã2ã2Ö&WFÓ¢‡GG3¢òöv—F‡V"æ6öÒ÷&–6†&VGG’ö'W'&÷ræ¶÷ÇVv–â÷&VÆV6W2÷Fr÷cã2ã2Ö&WF¥³ã2ã"Ö&WFÓ¢‡GG3¢òöv—F‡V"æ6öÒ÷&–6†&VGG’ö'W'&÷ræ¶÷ÇVv–â÷&VÆV6W2÷Fr÷cã2ã"Ö&WF¥³ã2ãÖ&WFÓ¢‡GG3¢òöv—F‡V"æ6öÒ÷&–6†&VGG’ö'W'&÷ræ¶÷ÇVv–â÷&VÆV6W2÷Fr÷cã2ãÖ&WF¥³ã2ãÖ&WFÓ¢‡GG3¢òöv—F‡V"æ6öÒ÷&–6†&VGG’ö'W'&÷ræ¶÷ÇVv–â÷&VÆV6W2÷Fr÷cã2ãÖ&WF¥³ã"ã"ÖÇ†Ó¢‡GG3¢òöv—F‡V"æ6öÒ÷&–6†&VGG’ö'W'&÷ræ¶÷ÇVv–â÷&VÆV6W2÷Fr÷cã"ã"ÖÇ†¥³ã"ãÖÇ†Ó¢‡GG3¢òöv—F‡V"æ6öÒ÷&–6†&VGG’ö'W'&÷ræ¶÷ÇVv–â÷&VÆV6W2÷Fr÷cã"ãÖÇ†¥³ã"ãÖÇ†Ó¢‡GG3¢òöv—F‡V"æ6öÒ÷&–6†&VGG’ö'W'&÷ræ¶÷ÇVv–â÷&VÆV6W2÷Fr÷cã"ãÖÇ† 

--- a/plugins/burrow.koplugin/burrow_bionic_epub.lua
+++ b/plugins/burrow.koplugin/burrow_bionic_epub.lua
@@ -1,0 +1,144 @@
+local Archiver = require("ffi/archiver")
+local logger = require("logger")
+
+local Transformer = require("burrow_bionic_xhtml")
+
+local Epub = {}
+
+local function dirname(path)
+    return path:match("^(.*[/\\])") or ""
+end
+
+local function normalizePath(path)
+    local parts = {}
+    path = (path or ""):gsub("\\", "/")
+    for part in path:gmatch("[^/]+") do
+        if part == "." or part == "" then
+            -- skip
+        elseif part == ".." then
+            if #parts > 0 then table.remove(parts) end
+        else
+            parts[#parts + 1] = part
+        end
+    end
+    return table.concat(parts, "/")
+end
+
+local function containerRootfile(xml)
+    if not xml then return nil end
+    return xml:match('<rootfile[^>]-full%-path%s*=%s*"([^"]+)"')
+        or xml:match("<rootfile[^>]-full%-path%s*=%s*'([^']+)'")
+end
+
+local function attr(tag, name)
+    return tag:match(name .. '%s*=%s*"([^"]*)"')
+        or tag:match(name .. "%s*=%s*'([^']*)'")
+end
+
+local function contentDocuments(opf, opfPath)
+    local result = {}
+    local base = dirname(opfPath)
+    for tag in (opf or ""):gmatch("<item%s+[^>]->") do
+        local media = attr(tag, "media%-type")
+        local href = attr(tag, "href")
+        if href and media
+            and (media == "application/xhtml+xml" or media == "text/html")
+        then
+            href = href:gsub("#.*$", "")
+            result[normalizePath(base .. href)] = true
+        end
+    end
+    return result
+end
+
+local function closeQuietly(object)
+    if object then pcall(object.close, object) end
+end
+
+function Epub.generate(sourcePath, targetPath)
+    local reader = Archiver.Reader:new()
+    if not reader:open(sourcePath) then
+        return false, "Could not open source EPUB."
+    end
+
+    -- Populate the reader entry lookup table, as KOReader's Archiver expects.
+    for _ in reader:iterate() do end
+
+    local container = reader:extractToMemory("META-INF/container.xml")
+    local opfPath = containerRootfile(container)
+    if not opfPath then
+        closeQuietly(reader)
+        return false, "EPUB package document was not found."
+    end
+    opfPath = normalizePath(opfPath)
+
+    local opf = reader:extractToMemory(opfPath)
+    if not opf then
+        closeQuietly(reader)
+        return false, "EPUB package document could not be read."
+    end
+    local transformSet = contentDocuments(opf, opfPath)
+
+    local tempPath = targetPath .. ".tmp"
+    os.remove(tempPath)
+    local writer = Archiver.Writer:new()
+    if not writer:open(tempPath, "epub") then
+        closeQuietly(reader)
+        return false, "Could not create Bionic Reading cache."
+    end
+
+    local mtime = os.time()
+    writer:setZipCompression("store")
+    if not writer:addFileFromMemory("mimetype", "application/epub+zip", mtime) then
+        closeQuietly(writer)
+        closeQuietly(reader)
+        os.remove(tempPath)
+        return false, "Could not write EPUB mimetype."
+    end
+    writer:setZipCompression("deflate")
+
+    for entry in reader:iterate() do
+        if entry.mode == "file" and entry.path ~= "mimetype" then
+            local content = reader:extractToMemory(entry.path)
+            if content == nil then
+                closeQuietly(writer)
+                closeQuietly(reader)
+                os.remove(tempPath)
+                return false, "Could not read EPUB entry: " .. tostring(entry.path)
+            end
+
+            if transformSet[normalizePath(entry.path)] then
+                local ok, transformed = pcall(Transformer.process, content)
+                if not ok or not transformed then
+                    logger.warn("[Burrow bionic] XHTML transform failed", entry.path, transformed)
+                    closeQuietly(writer)
+                    closeQuietly(reader)
+                    os.remove(tempPath)
+                    return false, "Could not transform EPUB text."
+                end
+                content = transformed
+            end
+
+            if not writer:addFileFromMemory(entry.path, content, mtime) then
+                closeQuietly(writer)
+                closeQuietly(reader)
+                os.remove(tempPath)
+                return false, "Could not write EPUB entry: " .. tostring(entry.path)
+            end
+        end
+    end
+
+    closeQuietly(writer)
+    closeQuietly(reader)
+
+    os.remove(targetPath)
+    local ok, err = os.rename(tempPath, targetPath)
+    if not ok then
+        os.remove(tempPath)
+        return false, "Could not finalize Bionic Reading cache: " .. tostring(err)
+    end
+
+    return true
+end
+
+return Epub

--- a/plugins/burrow.koplugin/burrow_bionic_reading.lua
+++ b/plugins/burrow.koplugin/burrow_bionic_reading.lua
@@ -1,0 +1,568 @@
+local bit = require("bit")
+local DataStorage = require("datastorage")
+local InfoMessage = require("ui/widget/infomessage")
+local UIManager = require("ui/uimanager")
+local lfs = require("libs/libkoreader-lfs")
+local logger = require("logger")
+local util = require("util")
+local _ = require("gettext")
+
+local Epub = require("burrow_bionic_epub")
+
+local MODULE_KEY = "burrow.bionic_reading"
+local existing = package.loaded[MODULE_KEY]
+if existing then return existing end
+
+local Bionic = {
+    key = MODULE_KEY,
+    SETTING_KEY = "burrow_bionic_reading",
+    CACHE_VERSION = "crosspoint45-v1",
+}
+package.loaded[MODULE_KEY] = Bionic
+
+local function isEpub(path)
+    return type(path) == "string" and path:lower():match("%.epub$") ~= nil
+end
+
+local function ensureDir(path)
+    if lfs.attributes(path, "mode") == "directory" then return true end
+    local ok = lfs.mkdir(path)
+    return ok or lfs.attributes(path, "mode") == "directory"
+end
+
+function Bionic.isEnabled()
+    return G_reader_settings:isTrue(Bionic.SETTING_KEY)
+end
+
+function Bionic.setEnabled(enabled)
+    G_reader_settings:saveSetting(Bionic.SETTING_KEY, enabled == true)
+    if type(G_reader_settings.flush) == "function" then
+        G_reader_settings:flush()
+    end
+end
+
+function Bionic.isSupportedFile(path)
+    return isEpub(path)
+end
+
+function Bionic.cacheDirectory()
+    local root
+    if type(DataStorage.getFullDataDir) == "function" then
+        root = DataStorage:getFullDataDir()
+    end
+    root = root or DataStorage:getDataDir()
+    return root .. "/cache/burrow-bionic"
+end
+
+function Bionic.cachePath(source)
+    local checksum = util.partialMD5(source)
+    if not checksum then return nil, "Could not identify this EPUB." end
+
+    local attrs = lfs.attributes(source) or {}
+    local identity = table.concat({
+        tostring(checksum),
+        tostring(attrs.size or ""),
+        tostring(attrs.modification or ""),
+        Bionic.CACHE_VERSION,
+    }, "-")
+    identity = identity:gsub("[^%w%-_%.]", "_")
+    return Bionic.cacheDirectory() .. "/" .. identity .. ".epub"
+end
+
+function Bionic.ensureCache(source)
+    if not Bionic.isSupportedFile(source) then
+        return nil, "Bionic Reading currently supports EPUB books."
+    end
+
+    local directory = Bionic.cacheDirectory()
+    if not ensureDir(directory) then
+        return nil, "Could not create Burrow's Bionic Reading cache."
+    end
+
+    local target, err = Bionic.cachePath(source)
+    if not target then return nil, err end
+    if lfs.attributes(target, "mode") == "file" then return target end
+
+    logger.info("[Burrow bionic] Building shadow EPUB", source)
+    local ok, buildErr = Epub.generate(source, target)
+    if not ok then
+        os.remove(target)
+        return nil, buildErr
+    end
+    return target
+end
+
+local function activeDocument(search)
+    return search and search.ui and search.ui.document
+        and search.ui.document._burrow_bionic_active == true
+end
+
+function Bionic.attachPluginClass(Burrow)
+    if type(Burrow) ~= "table" or Burrow._burrow_bionic_reader_context_hook then
+        return
+    end
+    Burrow._burrow_bionic_reader_context_hook = true
+
+    local originalDocSettingsLoad = Burrow.onDocSettingsLoad
+    function Burrow:onDocSettingsLoad(docSettings, document)
+        if originalDocSettingsLoad then
+            originalDocSettingsLoad(self, docSettings, document)
+        end
+
+        -- This event is emitted only by an actual ReaderUI instance, after
+        -- document modules/plugins are created but before CRengine performs its
+        -- full document load. Mark that exact CreDocument so file-manager cover
+        -- and metadata probes never get routed through the Bionic shadow EPUB.
+        local doc = document or self.document or (self.ui and self.ui.document)
+        if doc and doc.provider == "crengine" then
+            doc._burrow_bionic_reader_context = true
+        end
+    end
+end
+
+function Bionic.apply()
+    if Bionic.applied then return true end
+
+    local CreDocument = require("document/credocument")
+    local ReaderSearch = require("apps/reader/modules/readersearch")
+
+    if not CreDocument._burrow_bionic_shadow_loader_v1 then
+        CreDocument._burrow_bionic_shadow_loader_v1 = true
+        local originalLoad = CreDocument.loadDocument
+
+        function CreDocument:loadDocument(fullDocument)
+            if self._loaded or fullDocument == false
+                or self._burrow_bionic_reader_context ~= true
+                or not Bionic.isEnabled()
+                or not Bionic.isSupportedFile(self.file)
+            then
+                return originalLoad(self, fullDocument)
+            end
+
+            local originalFile = self.file
+            local shadow, shadowErr = Bionic.ensureCache(originalFile)
+            if not shadow then
+                logger.warn("[Burrow bionic] Falling back to original EPUB", shadowErr)
+                return originalLoad(self, fullDocument)
+            end
+
+            self.file = shadow
+            local ok, result = pcall(originalLoad, self, fullDocument)
+            self.file = originalFile
+            if not ok then error(result) end
+
+            if result then
+                self._burrow_bionic_active = true
+                self._burrow_bionic_shadow_file = shadow
+                self._burrow_bionic_original_file = originalFile
+                logger.info("[Burrow bionic] Loaded shadow EPUB")
+            end
+            return result
+        end
+    end
+
+    -- Current CRengine can search across inline text-node boundaries. Always
+    -- enable that flag on a Burrow shadow document, because each fixation point
+    -- intentionally introduces an inline <b> boundary inside a word.
+    if not ReaderSearch._burrow_bionic_search_bridge_v1 then
+        ReaderSearch._burrow_bionic_search_bridge_v1 = true
+
+        local originalSearch = ReaderSearch.search
+        function ReaderSearch:search(pattern, origin, searchType, caseInsensitive)
+            if not activeDocument(self) then
+                return originalSearch(self, pattern, origin, searchType, caseInsensitive)
+            end
+
+            local adjusted = {}
+            if type(searchType) == "table" then
+                for key, value in pairs(searchType) do adjusted[key] = value end
+            end
+            adjusted.flags = bit.bor(tonumber(adjusted.flags) or 0, 0x0001)
+            if adjusted.regex == nil then adjusted.regex = false end
+            return originalSearch(self, pattern, origin, adjusted, caseInsensitive)
+        end
+
+        local originalFindAll = ReaderSearch.findAllText
+        function ReaderSearch:findAllText(searchText)
+            if not activeDocument(self) or type(self.current_search_type) ~= "table" then
+                return originalFindAll(self, searchText)
+            end
+
+            local searchType = self.current_search_type
+            local previousFlags = searchType.flags
+            searchType.flags = bit.bor(tonumber(previousFlags) or 0, 0x0001)
+            local ok, a, b, c = pcall(originalFindAll, self, searchText)
+            searchType.flags = previousFlags
+            if not ok then error(a) end
+            return a, b, c
+        end
+    end
+
+    Bionic.applied = true
+    logger.info("[Burrow] Bionic Reading shadow loader available")
+    return true
+end
+
+local function closeReaderMenu(reader, touchMenu)
+    if reader and reader.menu and reader.menu.menu_container
+        and type(reader.menu.onCloseReaderMenu) == "function"
+    then
+        local ok, err = pcall(reader.menu.onCloseReaderMenu, reader.menu)
+        if ok then return end
+        logger.warn("[Burrow bionic] Could not close ReaderMenu", err)
+    end
+    if touchMenu then UIManager:close(touchMenu) end
+end
+
+-- A percentage is a useful coarse location across a reflow, but it is not a
+-- stable content identity: real bold changes line wrapping and total document
+-- height. Capture a short sequence of actual words near the current page start
+-- and use it as the primary post-reload anchor.
+local ANCHOR_WORD_COUNT = 10
+local ANCHOR_BACKTRACK_WORDS = 1800
+local ANCHOR_FORWARD_WORDS = 3800
+
+local function normalizeAnchorWord(text)
+    if type(text) ~= "string" then return nil end
+    text = text:gsub("^%s+", ""):gsub("%s+$", "")
+    text = text:gsub("%s+", " ")
+    if text == "" then return nil end
+    return text:lower()
+end
+
+local function getWordAt(document, wordStart)
+    if not document
+        or not wordStart
+        or type(document.getNextVisibleWordEnd) ~= "function"
+        or type(document.getTextFromXPointers) ~= "function"
+    then
+        return nil, nil
+    end
+
+    local okEnd, wordEnd = pcall(
+        document.getNextVisibleWordEnd,
+        document,
+        wordStart
+    )
+    if not okEnd or not wordEnd then
+        return nil, nil
+    end
+
+    local okText, text = pcall(
+        document.getTextFromXPointers,
+        document,
+        wordStart,
+        wordEnd,
+        false
+    )
+    if not okText then
+        return nil, wordEnd
+    end
+
+    return normalizeAnchorWord(text), wordEnd
+end
+
+local function nextWordStart(document, from)
+    if not document
+        or not from
+        or type(document.getNextVisibleWordStart) ~= "function"
+    then
+        return nil
+    end
+
+    local ok, xp = pcall(
+        document.getNextVisibleWordStart,
+        document,
+        from
+    )
+    if ok then return xp end
+end
+
+local function previousWordStart(document, from)
+    if not document
+        or not from
+        or type(document.getPrevVisibleWordStart) ~= "function"
+    then
+        return nil
+    end
+
+    local ok, xp = pcall(
+        document.getPrevVisibleWordStart,
+        document,
+        from
+    )
+    if ok then return xp end
+end
+
+local function captureTextAnchor(reader)
+    local document = reader and reader.document
+    if not document
+        or document.provider ~= "crengine"
+        or type(document.getXPointer) ~= "function"
+    then
+        return nil
+    end
+
+    local ok, current = pcall(document.getXPointer, document)
+    if not ok or not current then
+        return nil
+    end
+
+    local start = nextWordStart(document, current)
+    if not start then
+        start = previousWordStart(document, current)
+    end
+    if not start then
+        return nil
+    end
+
+    local words = {}
+    local cursor = start
+    local firstStart = start
+
+    -- Collect enough semantic words to make accidental duplicate matches very
+    -- unlikely, without depending on rendered page numbers or DOM node paths.
+    for _ = 1, ANCHOR_WORD_COUNT do
+        if not cursor then break end
+
+        local word, wordEnd = getWordAt(document, cursor)
+        if word then
+            words[#words + 1] = word
+        end
+
+        if not wordEnd then break end
+        local nextStart = nextWordStart(document, wordEnd)
+        if not nextStart or nextStart == cursor then break end
+        cursor = nextStart
+    end
+
+    if #words < 5 then
+        return nil
+    end
+
+    logger.dbg(
+        "[Burrow bionic] Captured semantic position anchor",
+        #words
+    )
+
+    return {
+        words = words,
+        source_xpointer = firstStart,
+    }
+end
+
+local function wordsMatch(window, expected)
+    if #window ~= #expected then return false end
+    for i = 1, #expected do
+        if window[i].word ~= expected[i] then
+            return false
+        end
+    end
+    return true
+end
+
+local function locateTextAnchor(reader, anchor)
+    if type(anchor) ~= "table"
+        or type(anchor.words) ~= "table"
+        or #anchor.words < 5
+    then
+        return nil
+    end
+
+    local document = reader and reader.document
+    if not document
+        or document.provider ~= "crengine"
+        or type(document.getXPointer) ~= "function"
+    then
+        return nil
+    end
+
+    local ok, coarse = pcall(document.getXPointer, document)
+    if not ok or not coarse then
+        return nil
+    end
+
+    -- Percentage restoration should already put us within a few pages. Move
+    -- backward enough to bracket the old location, then scan forward with a
+    -- small rolling word window. This avoids invoking ReaderSearch or altering
+    -- the user's search state/history.
+    local scanStart = coarse
+    for _ = 1, ANCHOR_BACKTRACK_WORDS do
+        local previous = previousWordStart(document, scanStart)
+        if not previous or previous == scanStart then break end
+        scanStart = previous
+    end
+
+    local cursor = scanStart
+    local window = {}
+
+    for _ = 1, ANCHOR_FORWARD_WORDS do
+        if not cursor then break end
+
+        local word, wordEnd = getWordAt(document, cursor)
+        if word then
+            window[#window + 1] = {
+                word = word,
+                xpointer = cursor,
+            }
+            if #window > #anchor.words then
+                table.remove(window, 1)
+            end
+
+            if #window == #anchor.words
+                and wordsMatch(window, anchor.words)
+            then
+                logger.dbg(
+                    "[Burrow bionic] Matched semantic position anchor"
+                )
+                return window[1].xpointer
+            end
+        end
+
+        if not wordEnd then break end
+        local nextStart = nextWordStart(document, wordEnd)
+        if not nextStart or nextStart == cursor then break end
+        cursor = nextStart
+    end
+
+    logger.dbg(
+        "[Burrow bionic] Semantic position anchor not found; keeping percentage fallback"
+    )
+    return nil
+end
+
+local function restoreSemanticAnchor(reader, anchor)
+    local xpointer = locateTextAnchor(reader, anchor)
+    if not xpointer
+        or not reader
+        or not reader.rolling
+        or type(reader.rolling.onGotoXPointer) ~= "function"
+    then
+        return false
+    end
+
+    local ok, err = pcall(
+        reader.rolling.onGotoXPointer,
+        reader.rolling,
+        xpointer
+    )
+    if not ok then
+        logger.warn(
+            "[Burrow bionic] Could not restore semantic position anchor",
+            err
+        )
+        return false
+    end
+
+    logger.dbg(
+        "[Burrow bionic] Restored semantic position anchor"
+    )
+    return true
+end
+
+local function captureReadingPercent(reader)
+    if not reader or not reader.rolling then
+        return nil
+    end
+
+    local rolling = reader.rolling
+    if type(rolling.getLastPercent) == "function" then
+        local ok, percent = pcall(rolling.getLastPercent, rolling)
+        if ok and type(percent) == "number" then
+            if percent < 0 then percent = 0 end
+            if percent > 1 then percent = 1 end
+            return percent
+        end
+    end
+
+    local footer = reader.view and reader.view.footer
+    local percent = footer and footer.percent_finished
+    if type(percent) == "number" then
+        if percent < 0 then percent = 0 end
+        if percent > 1 then percent = 1 end
+        return percent
+    end
+
+    return nil
+end
+
+local function restoreReadingPercent(reader, percent)
+    if type(percent) ~= "number"
+        or not reader
+        or not reader.rolling
+        or type(reader.rolling.onGotoPercent) ~= "function"
+    then
+        return false
+    end
+
+    local ok, err = pcall(
+        reader.rolling.onGotoPercent,
+        reader.rolling,
+        percent * 100
+    )
+    if not ok then
+        logger.warn(
+            "[Burrow bionic] Could not restore reading position after toggle",
+            err
+        )
+        return false
+    end
+
+    logger.dbg(
+        "[Burrow bionic] Restored reading position after toggle",
+        percent
+    )
+    return true
+end
+
+function Bionic.toggleFromQuickSettings(touchMenu)
+    local ReaderUI = require("apps/reader/readerui")
+    local reader = ReaderUI.instance
+    local savedPercent = captureReadingPercent(reader)
+    local savedTextAnchor = captureTextAnchor(reader)
+
+    Bionic.setEnabled(not Bionic.isEnabled())
+    local nowEnabled = Bionic.isEnabled()
+    closeReaderMenu(reader, touchMenu)
+
+    if not reader or not reader.document then return nowEnabled end
+
+    local file = reader.document.file
+    if not Bionic.isSupportedFile(file) then
+        UIManager:nextTick(function()
+            UIManager:show(InfoMessage:new{
+                text = _("Bionic Reading is saved globally and will apply to EPUB books."),
+                timeout = 3,
+            })
+        end)
+        return nowEnabled
+    end
+
+    UIManager:nextTick(function()
+        local info = InfoMessage:new{
+            text = nowEnabled and _("Applying Bionic Reading…")
+                or _("Returning to normal text…"),
+            timeout = 0,
+        }
+        UIManager:show(info)
+        UIManager:forceRePaint()
+
+        UIManager:scheduleIn(0.05, function()
+            reader:reloadDocument(nil, true, function(reopenedReader)
+                -- First get close using layout-independent relative progress.
+                restoreReadingPercent(reopenedReader, savedPercent)
+
+                -- Then pin the reload to the same actual words. Unlike page
+                -- count/height, the book's text is unchanged by the shadow
+                -- EPUB transformation.
+                restoreSemanticAnchor(reopenedReader, savedTextAnchor)
+
+                UIManager:close(info)
+            end)
+        end)
+    end)
+
+    return nowEnabled
+end
+
+return Bionic

--- a/plugins/burrow.koplugin/burrow_bionic_xhtml.lua
+++ b/plugins/burrow.koplugin/burrow_bionic_xhtml.lua
@@ -1,0 +1,212 @@
+local util = require("util")
+
+local Transformer = {}
+
+Transformer.RATIO_PERCENT = 45
+Transformer.MIN_PREFIX = 1
+Transformer.MAX_PREFIX = 9
+
+local OPAQUE = {
+    script = true, style = true, head = true, title = true,
+    svg = true, math = true, code = true, pre = true,
+    kbd = true, samp = true, var = true, tt = true,
+    b = true, strong = true,
+}
+
+local RAW_TEXT = { script = true, style = true }
+
+local function utf8Codepoint(ch)
+    local b1, b2, b3, b4 = ch:byte(1, 4)
+    if not b1 then return nil end
+    if b1 < 0x80 then
+        return b1
+    elseif b1 < 0xE0 and b2 then
+        return (b1 - 0xC0) * 0x40 + (b2 - 0x80)
+    elseif b1 < 0xF0 and b2 and b3 then
+        return (b1 - 0xE0) * 0x1000 + (b2 - 0x80) * 0x40 + (b3 - 0x80)
+    elseif b2 and b3 and b4 then
+        return (b1 - 0xF0) * 0x40000
+            + (b2 - 0x80) * 0x1000
+            + (b3 - 0x80) * 0x40
+            + (b4 - 0x80)
+    end
+    return b1
+end
+
+local function isWordChar(ch)
+    local cp = utf8Codepoint(ch)
+    if not cp then return false end
+    if cp < 128 then
+        local lower = cp
+        if lower >= 65 and lower <= 90 then lower = lower + 32 end
+        return (lower >= 97 and lower <= 122) or cp == 39
+    end
+    if cp >= 0x2000 and cp <= 0x2BFF then
+        return cp == 0x2018 or cp == 0x2019
+    end
+    if cp >= 0x00A1 and cp <= 0x00BF then
+        return cp == 0x00AA or cp == 0x00B5 or cp == 0x00BA
+    end
+    if cp >= 0x2E00 and cp <= 0x2E7F then return false end
+    if cp == 0x02D7 or cp == 0xFE63 or cp == 0xFF0D then return false end
+    return true
+end
+
+local function bionicizeText(text)
+    if not text or text == "" then return text end
+    local chars = util.splitToChars(text)
+    local out = {}
+    local i = 1
+    while i <= #chars do
+        if chars[i] == "&" then
+            local entity = { chars[i] }
+            i = i + 1
+            local guard = 0
+            while i <= #chars and guard < 16 do
+                entity[#entity + 1] = chars[i]
+                local done = chars[i] == ";"
+                i = i + 1
+                guard = guard + 1
+                if done then break end
+            end
+            out[#out + 1] = table.concat(entity)
+        elseif not isWordChar(chars[i]) then
+            out[#out + 1] = chars[i]
+            i = i + 1
+        else
+            local first = i
+            while i <= #chars and chars[i] ~= "&" and isWordChar(chars[i]) do
+                i = i + 1
+            end
+            local count = i - first
+            local prefixCount = math.floor(count * Transformer.RATIO_PERCENT / 100)
+            if prefixCount < Transformer.MIN_PREFIX then
+                prefixCount = Transformer.MIN_PREFIX
+            elseif prefixCount > Transformer.MAX_PREFIX then
+                prefixCount = Transformer.MAX_PREFIX
+            end
+            if prefixCount > count then prefixCount = count end
+            local prefix = table.concat(chars, "", first, first + prefixCount - 1)
+            local suffix = ""
+            if prefixCount < count then
+                suffix = table.concat(chars, "", first + prefixCount, i - 1)
+            end
+            out[#out + 1] = '<b class="burrow-bionic">' .. prefix .. '</b>' .. suffix
+        end
+    end
+    return table.concat(out)
+end
+
+local function findTagEnd(source, startPos)
+    local quote
+    local i = startPos + 1
+    while i <= #source do
+        local c = source:sub(i, i)
+        if quote then
+            if c == quote then quote = nil end
+        elseif c == '"' or c == "'" then
+            quote = c
+        elseif c == ">" then
+            return i
+        end
+        i = i + 1
+    end
+    return #source
+end
+
+local function tagInfo(tag)
+    local closing = tag:sub(2, 2) == "/"
+    local offset = closing and 3 or 2
+    local name = tag:sub(offset):match("^%s*([%w:_%-]+)")
+    if name then name = name:lower() end
+    local selfClosing = tag:match("/%s*>$") ~= nil
+    return name, closing, selfClosing
+end
+
+function Transformer.process(source)
+    if not source or source == "" then return source end
+    local out = {}
+    local text = {}
+    local stack = {}
+    local opaqueDepth = 0
+    local i = 1
+    local lowerSource
+
+    local function flushText()
+        if #text == 0 then return end
+        local chunk = table.concat(text)
+        text = {}
+        if opaqueDepth > 0 then
+            out[#out + 1] = chunk
+        else
+            out[#out + 1] = bionicizeText(chunk)
+        end
+    end
+
+    while i <= #source do
+        if source:sub(i, i) ~= "<" then
+            text[#text + 1] = source:sub(i, i)
+            i = i + 1
+        else
+            flushText()
+            if source:sub(i, i + 3) == "<!--" then
+                local close = source:find("-->", i + 4, true)
+                if not close then out[#out + 1] = source:sub(i); break end
+                out[#out + 1] = source:sub(i, close + 2)
+                i = close + 3
+            elseif source:sub(i, i + 8) == "<![CDATA[" then
+                local close = source:find("]]>", i + 9, true)
+                if not close then out[#out + 1] = source:sub(i); break end
+                out[#out + 1] = source:sub(i, close + 2)
+                i = close + 3
+            elseif source:sub(i, i + 1) == "<?" then
+                local close = source:find("?>", i + 2, true)
+                if not close then out[#out + 1] = source:sub(i); break end
+                out[#out + 1] = source:sub(i, close + 1)
+                i = close + 2
+            elseif source:sub(i, i + 1) == "<!" then
+                local close = source:find(">", i + 2, true) or #source
+                out[#out + 1] = source:sub(i, close)
+                i = close + 1
+            else
+                local close = findTagEnd(source, i)
+                local tag = source:sub(i, close)
+                local name, isClose, selfClosing = tagInfo(tag)
+                out[#out + 1] = tag
+                if name and not selfClosing then
+                    if isClose then
+                        for index = #stack, 1, -1 do
+                            if stack[index].name == name then
+                                if stack[index].opaque then
+                                    opaqueDepth = math.max(0, opaqueDepth - 1)
+                                end
+                                table.remove(stack, index)
+                                break
+                            end
+                        end
+                    else
+                        local opaque = OPAQUE[name] == true
+                        stack[#stack + 1] = { name = name, opaque = opaque }
+                        if opaque then opaqueDepth = opaqueDepth + 1 end
+                    end
+                end
+                i = close + 1
+                if name and RAW_TEXT[name] and not isClose and not selfClosing then
+                    lowerSource = lowerSource or source:lower()
+                    local rawClose = lowerSource:find("</" .. name, i, true)
+                    if rawClose then
+                        out[#out + 1] = source:sub(i, rawClose - 1)
+                        i = rawClose
+                    else
+                        out[#out + 1] = source:sub(i)
+                        break
+                    end
+                end
+            end
+        end
+    end
+    flushText()
+    return table.concat(out)
+end
+
+return Transformer

--- a/plugins/burrow.koplugin/burrow_document_inheritance.lua
+++ b/plugins/burrow.koplugin/burrow_document_inheritance.lua
@@ -1,0 +1,195 @@
+local logger = require("logger")
+
+local MODULE_KEY = "burrow.document_inheritance"
+local existing = package.loaded[MODULE_KEY]
+if existing then return existing end
+
+local Inheritance = {
+    key = MODULE_KEY,
+    PROFILE_KEY = "burrow_document_profiles",
+    PROFILE_VERSION = 1,
+}
+package.loaded[MODULE_KEY] = Inheritance
+
+local function clone(value, seen)
+    if type(value) ~= "table" then
+        return value
+    end
+    seen = seen or {}
+    if seen[value] then
+        return seen[value]
+    end
+    local copy = {}
+    seen[value] = copy
+    for key, item in pairs(value) do
+        copy[clone(key, seen)] = clone(item, seen)
+    end
+    return copy
+end
+
+local function isSerializableConfigValue(value)
+    local value_type = type(value)
+    return value_type == "number"
+        or value_type == "string"
+        or value_type == "table"
+end
+
+local function currentPrefix(ui)
+    local config = ui and ui.config
+    local options = config and config.options
+    local prefix = options and options.prefix
+    if prefix == "copt" or prefix == "kopt" then
+        return prefix
+    end
+end
+
+local function loadProfiles()
+    local profiles = G_reader_settings:readSetting(Inheritance.PROFILE_KEY)
+    if type(profiles) ~= "table"
+        or profiles.version ~= Inheritance.PROFILE_VERSION
+    then
+        profiles = { version = Inheritance.PROFILE_VERSION }
+    end
+    return profiles
+end
+
+local function saveProfiles(profiles)
+    profiles.version = Inheritance.PROFILE_VERSION
+    G_reader_settings:saveSetting(Inheritance.PROFILE_KEY, profiles)
+    if type(G_reader_settings.flush) == "function" then
+        G_reader_settings:flush()
+    end
+end
+
+local function captureProfile(ui)
+    local prefix = currentPrefix(ui)
+    local configurable = ui and ui.config and ui.config.configurable
+    if not prefix or type(configurable) ~= "table" then
+        return false
+    end
+
+    local profile = { settings = {} }
+
+    -- Mirror KOReader Configurable:saveSettings() from the live ReaderConfig
+    -- object, so Burrow inherits the whole current copt/kopt option set without
+    -- hard-coding individual document-setting names.
+    for key, value in pairs(configurable) do
+        if isSerializableConfigValue(value) then
+            profile.settings[prefix .. "_" .. key] = clone(value)
+        end
+    end
+
+    -- ReaderFont stores these separately from ReaderConfig.
+    if prefix == "copt" and ui.font then
+        if type(ui.font.font_face) == "string"
+            and ui.font.font_face ~= ""
+        then
+            profile.settings.font_face = ui.font.font_face
+        end
+        if type(ui.font.font_family_fonts) == "table" then
+            profile.settings.font_family_fonts = clone(ui.font.font_family_fonts)
+        end
+    end
+
+    local profiles = loadProfiles()
+    profiles[prefix] = profile
+    saveProfiles(profiles)
+
+    logger.dbg("[Burrow] Captured last-used document profile", prefix)
+    return true
+end
+
+local function applyProfile(ui, doc_settings)
+    if not doc_settings or type(doc_settings.saveSetting) ~= "function" then
+        return false
+    end
+
+    local prefix = currentPrefix(ui)
+    if not prefix then
+        return false
+    end
+
+    local profiles = loadProfiles()
+    local profile = profiles[prefix]
+    if type(profile) ~= "table" or type(profile.settings) ~= "table" then
+        return false
+    end
+
+    local applied = 0
+    for key, value in pairs(profile.settings) do
+        doc_settings:saveSetting(key, clone(value))
+        applied = applied + 1
+    end
+
+    logger.dbg("[Burrow] Applied last-used document profile", prefix, applied)
+    return applied > 0
+end
+
+function Inheritance.capture(ui)
+    local ok, result = pcall(captureProfile, ui)
+    if not ok then
+        logger.warn("[Burrow] Could not capture last-used document settings", result)
+        return false
+    end
+    return result == true
+end
+
+function Inheritance.applyToDocument(ui, doc_settings)
+    local ok, result = pcall(applyProfile, ui, doc_settings)
+    if not ok then
+        logger.warn("[Burrow] Could not apply last-used document settings", result)
+        return false
+    end
+    return result == true
+end
+
+function Inheritance.clearProfiles()
+    G_reader_settings:delSetting(Inheritance.PROFILE_KEY)
+    if type(G_reader_settings.flush) == "function" then
+        G_reader_settings:flush()
+    end
+end
+
+function Inheritance.attachPluginClass(Burrow)
+    if type(Burrow) ~= "table"
+        or Burrow._burrow_document_inheritance_hook
+    then
+        return false
+    end
+    Burrow._burrow_document_inheritance_hook = true
+
+    -- This runs before ReaderConfig and ReaderFont read the new book's sidecar.
+    -- Only the saved presentation-profile keys are replaced.
+    local originalDocSettingsLoad = Burrow.onDocSettingsLoad
+    function Burrow:onDocSettingsLoad(doc_settings, document)
+        if originalDocSettingsLoad then
+            local ok, err = pcall(
+                originalDocSettingsLoad,
+                self,
+                doc_settings,
+                document
+            )
+            if not ok then
+                logger.warn("[Burrow] Earlier DocSettingsLoad hook failed", err)
+            end
+        end
+        Inheritance.applyToDocument(self.ui, doc_settings)
+    end
+
+    -- Capture from live ReaderConfig/ReaderFont state, not from sidecar event
+    -- ordering, whenever KOReader saves the current reader session.
+    local originalSaveSettings = Burrow.onSaveSettings
+    function Burrow:onSaveSettings(...)
+        if originalSaveSettings then
+            local ok, err = pcall(originalSaveSettings, self, ...)
+            if not ok then
+                logger.warn("[Burrow] Earlier SaveSettings hook failed", err)
+            end
+        end
+        Inheritance.capture(self.ui)
+    end
+
+    return true
+end
+
+return Inheritance

--- a/plugins/burrow.koplugin/burrow_quick_settings_rotation.lua
+++ b/plugins/burrow.koplugin/burrow_quick_settings_rotation.lua
@@ -6,10 +6,10 @@ local logger = require("logger")
 local RotationFix = {}
 
 function RotationFix.apply()
-    if UIManager._burrow_quick_rotation_v3 then
+    if UIManager._burrow_quick_rotation_v5 then
         return true
     end
-    UIManager._burrow_quick_rotation_v3 = true
+    UIManager._burrow_quick_rotation_v5 = true
 
     local Screen = Device.screen
     local original_broadcast = UIManager.broadcastEvent
@@ -20,10 +20,121 @@ function RotationFix.apply()
         return source:find("2-quick-settings.lua", 1, true) ~= nil
     end
 
+    local function quickSettingsOpensFirst()
+        local quick_settings = package.loaded["burrow.internal.2_quick_settings"]
+        if not (quick_settings and quick_settings.applied) then
+            return false
+        end
+
+        local config = G_reader_settings:readSetting("rounded_quick_settings_panel")
+        if type(config) == "table" and config.open_on_start == false then
+            return false
+        end
+        return true
+    end
+
+    local function calledFromReaderMenu()
+        -- ReaderMenu dispatches ShowConfigMenu through ReaderUI, so it may be
+        -- several Lua frames below ReaderConfig:onShowConfigMenu().
+        for level = 2, 24 do
+            local info = debug.getinfo(level, "S")
+            if not info then break end
+            local source = tostring(info.source or "")
+            if source:find("apps/reader/modules/readermenu.lua", 1, true) then
+                return true
+            end
+        end
+        return false
+    end
+
+    -- KOReader normally opens ReaderConfig underneath ReaderMenu whenever
+    -- show_bottom_menu is enabled. That makes sense for KOReader's stock reader
+    -- menu, but Burrow's Quick Settings is intended to be a standalone top panel.
+    --
+    -- Suppress only the automatic ReaderMenu -> ReaderConfig opening when
+    -- Burrow Quick Settings is actually loaded and configured to open first.
+    -- Direct Text-control requests still use ReaderConfig normally.
+    local ReaderConfig = require("apps/reader/modules/readerconfig")
+    if not ReaderConfig._burrow_quick_settings_top_only then
+        ReaderConfig._burrow_quick_settings_top_only = true
+        local original_show_config = ReaderConfig.onShowConfigMenu
+
+        function ReaderConfig:onShowConfigMenu(...)
+            if quickSettingsOpensFirst() and calledFromReaderMenu() then
+                logger.dbg(
+                    "[Burrow] Suppressed automatic bottom ReaderConfig under Quick Settings"
+                )
+                return true
+            end
+            return original_show_config(self, ...)
+        end
+    end
+
+    local function showBurrowTextControlsSafely()
+        local ok, ReaderUI = pcall(require, "apps/reader/readerui")
+        local reader = ok and ReaderUI.instance or nil
+        if not reader or not reader.config then
+            return false
+        end
+
+        -- Close the reader top menu through KOReader's own controller so its
+        -- menu_container bookkeeping is cleared correctly.
+        if reader.menu
+            and reader.menu.menu_container
+            and type(reader.menu.onCloseReaderMenu) == "function"
+        then
+            local close_ok, close_err = pcall(
+                reader.menu.onCloseReaderMenu,
+                reader.menu
+            )
+            if not close_ok then
+                logger.warn(
+                    "[Burrow] Could not close ReaderMenu before Text controls",
+                    close_err
+                )
+            end
+        end
+
+        -- Compatibility path: if a config dialog is already present (for
+        -- example after changing settings or when Burrow's top-only rule does
+        -- not apply), simply leave it in place rather than creating a duplicate.
+        if reader.config.config_dialog then
+            logger.dbg("[Burrow] Reusing existing ReaderConfig dialog")
+            return true
+        end
+
+        -- In the normal Burrow path the bottom config panel was intentionally
+        -- not created when Quick Settings opened. Create exactly one after the
+        -- top ReaderMenu has closed.
+        UIManager:nextTick(function()
+            local current = ReaderUI.instance
+            if current
+                and current.config
+                and not current.config.config_dialog
+                and type(current.config.onShowConfigMenu) == "function"
+            then
+                logger.dbg("[Burrow] Opening Text controls after Quick Settings close")
+                current.config:onShowConfigMenu()
+            end
+        end)
+        return true
+    end
+
     function UIManager:broadcastEvent(event, ...)
-        local burrow_rotate = event
-            and event.handler == "onSwapRotation"
+        local from_burrow_quick_settings = event
             and calledFromBurrowQuickSettings()
+
+        -- Text controls are special. Do not broadcast ShowConfigMenu blindly:
+        -- close Burrow's top panel cleanly, then reuse or create one ReaderConfig.
+        if from_burrow_quick_settings
+            and event.handler == "onShowConfigMenu"
+            and showBurrowTextControlsSafely()
+        then
+            return true
+        end
+
+        local burrow_rotate = from_burrow_quick_settings
+            and event.handler == "onSwapRotation"
 
         if burrow_rotate then
             -- Cycle through all four physical orientations instead of KOReader's

--- a/plugins/burrow.koplugin/burrow_settings.lua
+++ b/plugins/burrow.koplugin/burrow_settings.lua
@@ -388,6 +388,8 @@ function BurrowSettings:removeAllSettings()
         "burrow_home_store_label_size_percent",
         "burrow_store_catalog_url",
         "burrow_store_catalog_title",
+        "burrow_bionic_reading",
+        "burrow_document_profiles",
     }
     for _, key in ipairs(keys) do
         G_reader_settings:delSetting(key)

--- a/plugins/burrow.koplugin/burrow_version.lua
+++ b/plugins/burrow.koplugin/burrow_version.lua
@@ -1,6 +1,6 @@
 return {
-    VERSION = "0.4.2",
-    DISPLAY_VERSION = "0.4.2",
+    VERSION = "0.4.3-beta.1",
+    DISPLAY_VERSION = "0.4.3-beta.1",
     STORE_ENGINE_VERSION = "1.2.1",
 
     -- Burrow is tested against KOReader 2026.07.2. Older releases are blocked,

--- a/plugins/burrow.koplugin/burrow_version.lua
+++ b/plugins/burrow.koplugin/burrow_version.lua
@@ -1,6 +1,6 @@
 return {
-    VERSION = "0.4.3-beta.1",
-    DISPLAY_VERSION = "0.4.3-beta.1",
+    VERSION = "0.4.3-beta.2",
+    DISPLAY_VERSION = "0.4.3-beta.2",
     STORE_ENGINE_VERSION = "1.2.1",
 
     -- Burrow is tested against KOReader 2026.07.2. Older releases are blocked,

--- a/plugins/burrow.koplugin/icons/quick_bionic.svg
+++ b/plugins/burrow.koplugin/icons/quick_bionic.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 24 24"><g fill="#000"><rect x="3" y="4" width="7.8" height="3.4" rx="1.5"/><rect x="11.8" y="4.7" width="9.2" height="2" rx="1"/><rect x="3" y="10.3" width="6.2" height="3.4" rx="1.5"/><rect x="10.2" y="11" width="7.7" height="2" rx="1"/><rect x="3" y="16.6" width="8.7" height="3.4" rx="1.5"/><rect x="12.7" y="17.3" width="8.3" height="2" rx="1"/></g></svg>

--- a/plugins/burrow.koplugin/internal_patches/2-quick-settings.lua
+++ b/plugins/burrow.koplugin/internal_patches/2-quick-settings.lua
@@ -17,6 +17,21 @@ function Module.apply()
 -- rounded tab highlights, and a rounded bottom footer.
 -- Remove any other copy of 2-quick-settings.lua before installing this file.
 
+local logger = require("logger")
+local BionicReading
+do
+    local ok, module_or_error = pcall(require, "burrow_bionic_reading")
+    if ok and type(module_or_error) == "table" then
+        local apply_ok, apply_result = pcall(module_or_error.apply)
+        if apply_ok and apply_result ~= false then
+            BionicReading = module_or_error
+        else
+            logger.warn("[Burrow] Bionic Reading disabled; initialization failed", apply_result)
+        end
+    else
+        logger.warn("[Burrow] Bionic Reading disabled; module failed to load", module_or_error)
+    end
+end
 local BD = require("ui/bidi")
 local Blitbuffer = require("ffi/blitbuffer")
 local Button = require("ui/widget/button")
@@ -199,6 +214,21 @@ local function saveConfig()
     G_reader_settings:saveSetting(CONFIG_KEY, config)
 end
 
+-- Bionic Reading is a fixed Reader Controls action, not a configurable
+-- Reader button. Remove configuration residue from earlier test overlays.
+local removed_legacy_bionic = false
+for index = #config.reader_order, 1, -1 do
+    if config.reader_order[index] == "bionic" then
+        table.remove(config.reader_order, index)
+        removed_legacy_bionic = true
+    end
+end
+if config.reader_buttons and config.reader_buttons.bionic ~= nil then
+    config.reader_buttons.bionic = nil
+    removed_legacy_bionic = true
+end
+if removed_legacy_bionic then saveConfig() end
+
 local function isReaderContext()
     local ok, ReaderUI = pcall(require, "apps/reader/readerui")
     return ok and ReaderUI.instance ~= nil
@@ -235,6 +265,19 @@ local button_defs = {
         label = _("Text"),
         reader = true,
         callback = function(menu) closeAndBroadcast(menu, "ShowConfigMenu") end,
+    },
+    bionic = {
+        icon = "quick_bionic",
+        label = _("Bionic"),
+        reader = true,
+        active_func = function()
+            return BionicReading and BionicReading.isEnabled() or false
+        end,
+        callback = function(touch_menu)
+            if BionicReading then
+                BionicReading.toggleFromQuickSettings(touch_menu)
+            end
+        end,
     },
     book_info = {
         icon = "quick_info",
@@ -366,12 +409,23 @@ local function visibleButtonEntries()
     local order = reader and config.reader_order or config.filemanager_order
     local enabled = reader and config.reader_buttons or config.filemanager_buttons
     local entries = {}
+    local bionic_inserted = false
+
     for _, id in ipairs(order) do
         local def = button_defs[id]
         local context_ok = def and not ((def.reader and not reader) or (def.filemanager and reader))
         if def and context_ok and enabled[id] then
             table.insert(entries, { id = id, def = def })
         end
+
+        if reader and BionicReading and id == "text" and not bionic_inserted then
+            table.insert(entries, { id = "bionic", def = button_defs.bionic })
+            bionic_inserted = true
+        end
+    end
+
+    if reader and BionicReading and not bionic_inserted then
+        table.insert(entries, { id = "bionic", def = button_defs.bionic })
     end
     return entries
 end

--- a/plugins/burrow.koplugin/main.lua
+++ b/plugins/burrow.koplugin/main.lua
@@ -117,6 +117,44 @@ BurrowLoader:loadEarlyModules()
 local Burrow = WidgetContainer:extend {
     name = "burrow",
 }
+
+-- Bionic Reading is loaded only with Burrow Quick Settings. When present, let
+-- it mark the actual ReaderUI document during DocSettingsLoad so its CRengine
+-- shadow-file hook never touches File Manager metadata/cover probes.
+local BionicReading = package.loaded["burrow.bionic_reading"]
+if type(BionicReading) == "table"
+    and type(BionicReading.attachPluginClass) == "function"
+then
+    local ok, err = pcall(BionicReading.attachPluginClass, Burrow)
+    if not ok then
+        logger.warn(burrow_debug.logprefix, "Bionic Reading reader hook could not attach", err)
+    end
+end
+
+local inheritance_ok, DocumentInheritance = pcall(
+    require,
+    "burrow_document_inheritance"
+)
+if inheritance_ok
+    and type(DocumentInheritance) == "table"
+    and type(DocumentInheritance.attachPluginClass) == "function"
+then
+    local ok, err = pcall(DocumentInheritance.attachPluginClass, Burrow)
+    if not ok then
+        logger.warn(
+            burrow_debug.logprefix,
+            "Last-used document settings hook could not attach",
+            err
+        )
+    end
+else
+    logger.warn(
+        burrow_debug.logprefix,
+        "Last-used document settings module could not load",
+        DocumentInheritance
+    )
+end
+
 Burrow._compatibility = compatibility
 Burrow._compatibility_notice = compatibility.warning
 


### PR DESCRIPTION
Adds the device-tested Bionic Reading feature and last-used document-setting inheritance for the 0.4.3 prerelease line. Bionic uses a cached shadow EPUB with real bold fixation prefixes, keeps the original EPUB untouched, preserves Search in Book, and restores position with percentage plus nearby semantic text anchoring. Document presentation settings follow the most recently used setup while reading position, highlights, bookmarks, and other book-specific data remain separate. A small occasional page drift when toggling Bionic is documented as a known limitation. Stable main remains on 0.4.2. This draft PR exists to validate the exact beta.2 candidate before the prerelease publish branch is moved.