### PR TITLE
Burrow 0.4.3-beta.3 soft palette

### DIFF
--- a/plugins/burrow.koplugin/burrow_loader.lua
+++ b/plugins/burrow.koplugin/burrow_loader.lua
@@ -355,6 +355,7 @@ end
 function Loader:getUserNotices()
     local notices = {}
     local labels = {
+        soft_palette = "Soft light/dark palette",
         library_visuals = "Library styling",
         library_navigation = "Library navigation",
         settings_menu = "Burrow Settings",

--- a/plugins/burrow.koplugin/burrow_settings.lua
+++ b/plugins/burrow.koplugin/burrow_settings.lua
@@ -176,6 +176,11 @@ function BurrowSettings:getModuleManifest()
             filename = "2-quick-settings.lua",
             feature = "quick_settings",
         })
+        add("quick_settings_native_night", "2-quick-settings-native-night.lua", "early", {
+            filename = "2-quick-settings-native-night.lua",
+            feature = "quick_settings",
+            depends = { "quick_settings" },
+        })
     end
     if self:isFeatureEnabled("statusbar") then
         add("statusbar", "2-statusbar-margins-presets.lua", "early", {
@@ -202,6 +207,11 @@ function BurrowSettings:getModuleManifest()
         filename = "2-zz-burrow-settings-menu.lua",
         feature = "settings_menu",
         depends = { "library_core" },
+    })
+    add("soft_palette_settings", "2-zzzz-soft-palette-settings.lua", "instance", {
+        filename = "2-zzzz-soft-palette-settings.lua",
+        feature = "settings_menu",
+        depends = { "library_core", "settings_menu_cleanup" },
     })
 
     return modules

--- a/plugins/burrow.koplugin/burrow_settings.lua
+++ b/plugins/burrow.koplugin/burrow_settings.lua
@@ -4,6 +4,12 @@ local BurrowSettings = {}
 
 BurrowSettings.features = {
     {
+        id = "soft_palette",
+        text = _("Soft light and dark palette"),
+        help_text = _("Replace KOReader's pure white and black UI source colors with softer neutral tones. Night mode uses KOReader's native inversion."),
+        default = true,
+    },
+    {
         id = "library_visuals",
         text = _("Burrow library styling"),
         help_text = _("Rounded covers, folder styling, captions, badges, the top bar, hero card, and the expanded cover grid."),
@@ -154,6 +160,17 @@ function BurrowSettings:getModuleManifest()
             depends = { "library_core" },
         })
     end
+
+    -- Apply the shared source palette before any other early UI module builds
+    -- widgets or icons. It is its own guarded feature so a palette conflict can
+    -- be quarantined without disabling Quick Settings, the library, or reader.
+    if self:isFeatureEnabled("soft_palette") then
+        add("soft_palette", "2-soft-palette.lua", "early", {
+            filename = "2-soft-palette.lua",
+            feature = "soft_palette",
+        })
+    end
+
     if self:isFeatureEnabled("quick_settings") then
         add("quick_settings", "2-quick-settings.lua", "early", {
             filename = "2-quick-settings.lua",

--- a/plugins/burrow.koplugin/burrow_version.lua
+++ b/plugins/burrow.koplugin/burrow_version.lua
@@ -1,6 +1,6 @@
 return {
-    VERSION = "0.4.3-beta.2",
-    DISPLAY_VERSION = "0.4.3-beta.2",
+    VERSION = "0.4.3-beta.3",
+    DISPLAY_VERSION = "0.4.3-beta.3",
     STORE_ENGINE_VERSION = "1.2.1",
 
     -- Burrow is tested against KOReader 2026.07.2. Older releases are blocked,

--- a/plugins/burrow.koplugin/internal_patches/2-quick-settings-native-night.lua
+++ b/plugins/burrow.koplugin/internal_patches/2-quick-settings-native-night.lua
@@ -1,0 +1,63 @@
+local MODULE_KEY = "burrow.internal.2_quick_settings_native_night"
+local existing_module = package.loaded[MODULE_KEY]
+if existing_module then return existing_module end
+
+local Module = {
+    key = MODULE_KEY,
+    phase = "early",
+    filename = "2-quick-settings-native-night.lua",
+}
+package.loaded[MODULE_KEY] = Module
+
+local function getUpValue(fn, wanted)
+    if type(fn) ~= "function" then return nil end
+    for index = 1, 100 do
+        local name, value = debug.getupvalue(fn, index)
+        if not name then break end
+        if name == wanted then return value end
+    end
+end
+
+function Module.apply()
+    if Module.applied then return true end
+
+    local quick = package.loaded["burrow.internal.2_quick_settings"]
+    if type(quick) ~= "table" or type(quick.getSettingsMenu) ~= "function" then
+        return false, "Quick Settings module is unavailable"
+    end
+
+    -- buildSettingsMenu -> makeButtonSettings -> button_defs. Patch only the
+    -- Night action instead of replacing or reloading the full Quick Settings
+    -- module. This keeps the already-tested panel/layout code untouched.
+    local makeButtonSettings = getUpValue(quick.getSettingsMenu, "makeButtonSettings")
+    local button_defs = getUpValue(makeButtonSettings, "button_defs")
+    if type(button_defs) ~= "table"
+        or type(button_defs.night) ~= "table"
+    then
+        return false, "Could not locate Quick Settings Night action"
+    end
+
+    local Event = require("ui/event")
+    local UIManager = require("ui/uimanager")
+
+    button_defs.night.callback = function(touch_menu)
+        -- Use KOReader's native DeviceListener path. It handles screen
+        -- inversion, CRengine cache reset, highlight refresh, persistence and
+        -- the repaint as one coordinated Night Mode transition.
+        UIManager:broadcastEvent(Event:new("ToggleNightMode"))
+
+        UIManager:nextTick(function()
+            if touch_menu
+                and touch_menu.item_table
+                and touch_menu.item_table.panel
+            then
+                touch_menu:updateItems(1)
+            end
+        end)
+    end
+
+    Module.applied = true
+    return true
+end
+
+return Module

--- a/plugins/burrow.koplugin/internal_patches/2-soft-palette.lua
+++ b/plugins/burrow.koplugin/internal_patches/2-soft-palette.lua
@@ -1,0 +1,120 @@
+local MODULE_KEY = "burrow.internal.2_soft_palette"
+local existing_module = package.loaded[MODULE_KEY]
+if existing_module then return existing_module end
+
+local Module = {
+    key = MODULE_KEY,
+    phase = "early",
+    filename = "2-soft-palette.lua",
+}
+package.loaded[MODULE_KEY] = Module
+
+function Module.apply()
+    if Module.applied then return true end
+
+    -- Preflight every dependency before mutating any shared KOReader object.
+    -- If any of these fail, Burrow's guarded loader quarantines only the soft
+    -- palette feature and the rest of Burrow continues unchanged.
+    local Blitbuffer = require("ffi/blitbuffer")
+    local CreDocument = require("document/credocument")
+    local ImageWidget = require("ui/widget/imagewidget")
+    local ReaderStyleTweak = require("apps/reader/modules/readerstyletweak")
+    local logger = require("logger")
+    local userpatch = require("userpatch")
+
+    local WHITE_DEFAULT = 0xFF
+    local BLACK_DEFAULT = 0x00
+    local WHITE_SOFT = 0xF2
+    local BLACK_SOFT = 0x20
+
+    local current_white = tonumber(Blitbuffer.COLOR_WHITE.a)
+    local current_black = tonumber(Blitbuffer.COLOR_BLACK.a)
+
+    -- Do not silently fight another user patch/theme that has already changed
+    -- KOReader's core named colors. Already-soft values are accepted so a
+    -- harmless duplicate apply cannot break startup.
+    local white_ok = current_white == WHITE_DEFAULT or current_white == WHITE_SOFT
+    local black_ok = current_black == BLACK_DEFAULT or current_black == BLACK_SOFT
+    if not white_ok or not black_ok then
+        return false, string.format(
+            "KOReader UI palette was already customized (white=%s, black=%s)",
+            tostring(current_white), tostring(current_black)
+        )
+    end
+
+    -- This is the central color swap. These are Color8 aggregate cdata objects,
+    -- and KOReader widgets keep references to these shared named colors. Mutate
+    -- the objects in place so already-loaded class defaults follow the palette
+    -- without replacing any widget paint method.
+    Blitbuffer.COLOR_WHITE.a = WHITE_SOFT
+    Blitbuffer.COLOR_BLACK.a = BLACK_SOFT
+
+    -- IconWidget normally flattens transparent SVG/PNG icons onto
+    -- Blitbuffer.COLOR_WHITE before caching them. Clear that module-local cache
+    -- through KOReader's supported userpatch helper so future icon instances
+    -- are rebuilt against the new soft white instead of reusing old 255-white
+    -- cached buffers. Cache failure is non-fatal; never take Burrow down for it.
+    local cache_ok, cache_err = pcall(function()
+        local image_cache = userpatch.getUpValue(ImageWidget._loadfile, "ImageCache")
+        if image_cache and type(image_cache.clear) == "function" then
+            image_cache:clear()
+        end
+    end)
+    if not cache_ok then
+        logger.warn("[Burrow] Soft palette could not clear ImageWidget cache", cache_err)
+    end
+
+    -- CRengine draws the book page itself, so it does not naturally use the UI
+    -- COLOR_WHITE/COLOR_BLACK objects. Give reflowable documents the matching
+    -- source palette, unless the user explicitly chose a CRE background/image.
+    -- KOReader's native Night Mode inversion then creates #0D0D0F/#DFDFDF.
+    local READER_BACKGROUND = 0xF2F2F0
+    local READER_TEXT_CSS = [[
+html,
+body {
+    color: #202020 !important;
+}
+]]
+
+    local function hasUserReaderPalette()
+        return G_reader_settings:has("cre_background_color")
+            or G_reader_settings:has("cre_background_image")
+    end
+
+    if not CreDocument._burrow_soft_palette_v5 then
+        CreDocument._burrow_soft_palette_v5 = true
+        local original_setupDefaultView = CreDocument.setupDefaultView
+
+        function CreDocument:setupDefaultView(...)
+            local result = original_setupDefaultView(self, ...)
+            if not hasUserReaderPalette() then
+                self:setBackgroundColor(READER_BACKGROUND)
+            end
+            return result
+        end
+    end
+
+    -- ReaderTypeset asks ReaderStyleTweak for its final CSS immediately before
+    -- applying the document stylesheet. Append only an inherited body color;
+    -- explicit descendant/publisher colors can still override the inheritance.
+    if not ReaderStyleTweak._burrow_soft_palette_v5 then
+        ReaderStyleTweak._burrow_soft_palette_v5 = true
+        local original_getCssText = ReaderStyleTweak.getCssText
+
+        function ReaderStyleTweak:getCssText()
+            local css = original_getCssText(self)
+            if hasUserReaderPalette() then
+                return css
+            end
+            if css and css ~= "" then
+                return css .. "\n" .. READER_TEXT_CSS
+            end
+            return READER_TEXT_CSS
+        end
+    end
+
+    Module.applied = true
+    return true
+end
+
+return Module

--- a/plugins/burrow.koplugin/internal_patches/2-zzzz-soft-palette-settings.lua
+++ b/plugins/burrow.koplugin/internal_patches/2-zzzz-soft-palette-settings.lua
@@ -1,0 +1,72 @@
+local MODULE_KEY = "burrow.internal.2_zzzz_soft_palette_settings"
+local existing_module = package.loaded[MODULE_KEY]
+if existing_module then return existing_module end
+
+local Module = {
+    key = MODULE_KEY,
+    phase = "instance",
+    filename = "2-zzzz-soft-palette-settings.lua",
+}
+package.loaded[MODULE_KEY] = Module
+
+function Module.apply(plugin)
+    if Module.applied then return true end
+    if not plugin or plugin._burrow_soft_palette_settings_patched then
+        Module.applied = true
+        return true
+    end
+    plugin._burrow_soft_palette_settings_patched = true
+
+    local BurrowLoader = require("burrow_loader")
+    local BurrowSettings = require("burrow_settings")
+    local UIManager = require("ui/uimanager")
+    local _ = require("l10n.gettext")
+
+    local original_add_to_main_menu = plugin.addToMainMenu
+    function plugin:addToMainMenu(menu_items)
+        original_add_to_main_menu(self, menu_items)
+
+        local root = menu_items and menu_items.filemanager_display_mode
+        local items = root and root.sub_item_table
+        if type(items) ~= "table" then return end
+
+        for _, item in ipairs(items) do
+            if item._burrow_soft_palette_appearance then
+                return
+            end
+        end
+
+        local function enabled()
+            return BurrowSettings:isFeatureEnabled("soft_palette")
+        end
+
+        local appearance = {
+            text = _("Appearance"),
+            _burrow_soft_palette_appearance = true,
+            sub_item_table = {
+                {
+                    text = _("Use softer black and white"),
+                    help_text = _("Use Burrow's softer neutral white and black instead of KOReader's pure white and black. Night mode uses KOReader's native inversion. Restart required."),
+                    checked_func = enabled,
+                    callback = function()
+                        local new_enabled = not enabled()
+                        BurrowSettings:setFeatureEnabled("soft_palette", new_enabled)
+                        if new_enabled then
+                            BurrowLoader:clearQuarantine("soft_palette")
+                        end
+                        UIManager:askForRestart()
+                    end,
+                },
+            },
+        }
+
+        -- Burrow Settings currently begins with Library. Appearance belongs
+        -- immediately after it, before Navigation and the functional sections.
+        table.insert(items, math.min(2, #items + 1), appearance)
+    end
+
+    Module.applied = true
+    return true
+end
+
+return Module


### PR DESCRIPTION
Promote the tested soft black/white palette into the prerelease line.

Changes:
- add a guarded soft palette feature using KOReader's shared source colors
- keep reflowable reader pages on the matching softer background/text palette
- route Burrow Night through KOReader's native Night Mode transition
- add Burrow Settings > Appearance > Use softer black and white
- keep pure black/white available by disabling the Appearance option and restarting
- bump prerelease version to 0.4.3-beta.3

Validation already performed locally: all 87 plugin Lua files parse successfully. This PR is for CI validation before advancing the prerelease branch.