### PR TITLE
Burrow 0.4.3-beta.4 reader footer and palette refinements

### DIFF
--- a/plugins/burrow.koplugin/burrow_soft_palette_epub.lua
+++ b/plugins/burrow.koplugin/burrow_soft_palette_epub.lua
@@ -1,0 +1,444 @@
+local Archiver = require("ffi/archiver")
+local Blitbuffer = require("ffi/blitbuffer")
+local DataStorage = require("datastorage")
+local RenderImage = require("ui/renderimage")
+local lfs = require("libs/libkoreader-lfs")
+local logger = require("logger")
+local util = require("util")
+
+local Epub = {
+    CACHE_VERSION = "ornaments-v1-f2f2f0-202020",
+}
+
+local BLACK_R, BLACK_G, BLACK_B = 0x20, 0x20, 0x20
+local WHITE_R, WHITE_G, WHITE_B = 0xF2, 0xF2, 0xF0
+
+-- Keep this deliberately conservative. The goal is to catch scene-break art,
+-- chapter flourishes and other small monochrome assets without recoloring
+-- illustrations, covers, comics or photographs.
+local MAX_RASTER_PIXELS = 220000
+local MAX_RASTER_DIMENSION = 1400
+local MAX_COMPRESSED_BYTES = 2 * 1024 * 1024
+local SAMPLE_TARGET = 6000
+local MAX_CHROMA = 18
+local MAX_COLORED_SAMPLE_FRACTION = 0.02
+local MIN_EXTREME_SAMPLE_FRACTION = 0.82
+local MIN_LIGHT_SAMPLE_FRACTION = 0.20
+local MIN_DARK_SAMPLE_FRACTION = 0.002
+
+local function dirname(path)
+    return path:match("^(.*[/\\])") or ""
+end
+
+local function normalizePath(path)
+    local parts = {}
+    path = (path or ""):gsub("\\", "/")
+    for part in path:gmatch("[^/]+") do
+        if part == "." or part == "" then
+            -- skip
+        elseif part == ".." then
+            if #parts > 0 then table.remove(parts) end
+        else
+            parts[#parts + 1] = part
+        end
+    end
+    return table.concat(parts, "/")
+end
+
+local function containerRootfile(xml)
+    if not xml then return nil end
+    return xml:match('<rootfile[^>]-full%-path%s*=%s*"([^"]+)"')
+        or xml:match("<rootfile[^>]-full%-path%s*=%s*'([^']+)'")
+end
+
+local function attr(tag, name)
+    return tag:match(name .. '%s*=%s*"([^"]*)"')
+        or tag:match(name .. "%s*=%s*'([^']*)'")
+end
+
+local function imageDocuments(opf, opfPath)
+    local result = {}
+    local base = dirname(opfPath)
+
+    local epub2_cover_id = (opf or ""):match(
+        '<meta[^>]-name%s*=%s*"cover"[^>]-content%s*=%s*"([^"]+)"'
+    ) or (opf or ""):match(
+        "<meta[^>]-name%s*=%s*'cover'[^>]-content%s*=%s*'([^']+)'"
+    )
+
+    for tag in (opf or ""):gmatch("<item%s+[^>]->") do
+        local id = attr(tag, "id")
+        local media = attr(tag, "media%-type")
+        local href = attr(tag, "href")
+        local properties = attr(tag, "properties") or ""
+        if href and media then
+            local supported = media == "image/png"
+                or media == "image/jpeg"
+                or media == "image/svg+xml"
+            if supported then
+                href = href:gsub("#.*$", "")
+                local path = normalizePath(base .. href)
+                local is_cover = properties:find("cover%-image") ~= nil
+                    or (epub2_cover_id and id == epub2_cover_id)
+                    or path:lower():find("cover", 1, true) ~= nil
+                if not is_cover then
+                    result[path] = media
+                end
+            end
+        end
+    end
+    return result
+end
+
+local function closeQuietly(object)
+    if object then pcall(object.close, object) end
+end
+
+local function ensureDir(path)
+    if lfs.attributes(path, "mode") == "directory" then return true end
+    local ok = lfs.mkdir(path)
+    return ok or lfs.attributes(path, "mode") == "directory"
+end
+
+function Epub.cacheDirectory()
+    local root
+    if type(DataStorage.getFullDataDir) == "function" then
+        root = DataStorage:getFullDataDir()
+    end
+    root = root or DataStorage:getDataDir()
+    return root .. "/cache/burrow-soft-palette"
+end
+
+function Epub.cachePath(source)
+    local checksum = util.partialMD5(source)
+    if not checksum then return nil, "Could not identify this EPUB." end
+
+    local attrs = lfs.attributes(source) or {}
+    local identity = table.concat({
+        tostring(checksum),
+        tostring(attrs.size or ""),
+        tostring(attrs.modification or ""),
+        Epub.CACHE_VERSION,
+    }, "-")
+    identity = identity:gsub("[^%w%-_%.]", "_")
+    return Epub.cacheDirectory() .. "/" .. identity .. ".epub"
+end
+
+local function visibleChannel(channel, alpha)
+    -- MuPDF commonly returns premultiplied alpha. Adding the uncovered white
+    -- portion gives us the visible value on a white page and also behaves well
+    -- for straight-alpha black/white artwork.
+    local value = channel + (255 - alpha)
+    if value > 255 then value = 255 end
+    return value
+end
+
+local function visibleRGB(bb, x, y)
+    local color = bb:getPixel(x, y):getColorRGB32()
+    local alpha = tonumber(color.alpha) or 255
+    return visibleChannel(tonumber(color.r) or 0, alpha),
+        visibleChannel(tonumber(color.g) or 0, alpha),
+        visibleChannel(tonumber(color.b) or 0, alpha)
+end
+
+local function luminance(r, g, b)
+    -- Integer approximation of Rec. 601 luma.
+    return math.floor((77 * r + 150 * g + 29 * b + 128) / 256)
+end
+
+local function isSmallMonochromeRaster(bb)
+    local w, h = bb:getWidth(), bb:getHeight()
+    if w < 4 or h < 4 then return false end
+    if w > MAX_RASTER_DIMENSION or h > MAX_RASTER_DIMENSION then return false end
+    local area = w * h
+    if area > MAX_RASTER_PIXELS then return false end
+
+    local step = math.max(1, math.floor(math.sqrt(area / SAMPLE_TARGET)))
+    local total, colored, extremes, light, dark = 0, 0, 0, 0, 0
+
+    for y = 0, h - 1, step do
+        for x = 0, w - 1, step do
+            local r, g, b = visibleRGB(bb, x, y)
+            local high = math.max(r, g, b)
+            local low = math.min(r, g, b)
+            if high - low > MAX_CHROMA then colored = colored + 1 end
+
+            local luma = luminance(r, g, b)
+            if luma <= 96 then dark = dark + 1 end
+            if luma >= 200 then light = light + 1 end
+            if luma <= 96 or luma >= 200 then extremes = extremes + 1 end
+            total = total + 1
+        end
+    end
+
+    if total == 0 then return false end
+    if colored / total > MAX_COLORED_SAMPLE_FRACTION then return false end
+    if extremes / total < MIN_EXTREME_SAMPLE_FRACTION then return false end
+    if light / total < MIN_LIGHT_SAMPLE_FRACTION then return false end
+    if dark / total < MIN_DARK_SAMPLE_FRACTION then return false end
+    return true
+end
+
+local function remapChannel(luma, target_white)
+    return math.floor(BLACK_R + (luma * (target_white - BLACK_R) + 127) / 255)
+end
+
+local function recolorRaster(content, media, tempBase)
+    if #content > MAX_COMPRESSED_BYTES then return nil end
+
+    local ok, bb = pcall(
+        RenderImage.renderImageDataWithMupdf,
+        RenderImage,
+        content,
+        #content
+    )
+    if not ok or not bb then return nil end
+
+    if not isSmallMonochromeRaster(bb) then
+        pcall(bb.free, bb)
+        return nil
+    end
+
+    local w, h = bb:getWidth(), bb:getHeight()
+    local out = Blitbuffer.new(w, h, Blitbuffer.TYPE_BBRGB24)
+    local ColorRGB24 = Blitbuffer.ColorRGB24
+
+    for y = 0, h - 1 do
+        for x = 0, w - 1 do
+            local r, g, b = visibleRGB(bb, x, y)
+            local luma = luminance(r, g, b)
+            local rr = remapChannel(luma, WHITE_R)
+            local gg = remapChannel(luma, WHITE_G)
+            local bbv = remapChannel(luma, WHITE_B)
+            out:setPixel(x, y, ColorRGB24(rr, gg, bbv))
+        end
+    end
+
+    local suffix = media == "image/jpeg" and ".jpg" or ".png"
+    local tempPath = tempBase .. suffix
+    os.remove(tempPath)
+
+    local write_ok, write_err
+    if media == "image/jpeg" then
+        write_ok, write_err = pcall(out.writeJPG, out, tempPath, 95)
+    else
+        write_ok, write_err = pcall(out.writePNG, out, tempPath)
+    end
+
+    pcall(out.free, out)
+    pcall(bb.free, bb)
+
+    if not write_ok then
+        os.remove(tempPath)
+        logger.warn("[Burrow palette] Could not encode recolored ornament", write_err)
+        return nil
+    end
+
+    local file = io.open(tempPath, "rb")
+    if not file then
+        os.remove(tempPath)
+        return nil
+    end
+    local transformed = file:read("*a")
+    file:close()
+    os.remove(tempPath)
+    return transformed
+end
+
+local function remapGrayValue(value)
+    local r = remapChannel(value, WHITE_R)
+    local g = remapChannel(value, WHITE_G)
+    local b = remapChannel(value, WHITE_B)
+    return string.format("#%02x%02x%02x", r, g, b)
+end
+
+local function recolorSvg(content)
+    if #content > 100000 then return nil end
+    local lower = content:lower()
+    if lower:find("<image", 1, true)
+        or lower:find("lineargradient", 1, true)
+        or lower:find("radialgradient", 1, true)
+        or lower:find("<filter", 1, true)
+        or lower:find("<pattern", 1, true)
+    then
+        return nil
+    end
+
+    local paths = 0
+    for _ in lower:gmatch("<path[%s>]" ) do
+        paths = paths + 1
+        if paths > 80 then return nil end
+    end
+
+    local changed = false
+    local saw_dark = false
+
+    local transformed = content:gsub("#([%x]+)", function(hex)
+        local n = #hex
+        local value
+        if n == 3 then
+            local a, b, c = hex:sub(1,1), hex:sub(2,2), hex:sub(3,3)
+            if a:lower() == b:lower() and b:lower() == c:lower() then
+                value = tonumber(a .. a, 16)
+            end
+        elseif n == 6 then
+            local r = tonumber(hex:sub(1,2), 16)
+            local g = tonumber(hex:sub(3,4), 16)
+            local b = tonumber(hex:sub(5,6), 16)
+            if r == g and g == b then value = r end
+        end
+        if value then
+            if value <= 96 then saw_dark = true end
+            changed = true
+            return remapGrayValue(value)
+        end
+        return "#" .. hex
+    end)
+
+    transformed = transformed:gsub("([Rr][Gg][Bb]%s*%(%s*)(%d+)(%s*,%s*)(%d+)(%s*,%s*)(%d+)(%s*%))", function(prefix, r, comma1, g, comma2, b, suffix)
+        r, g, b = tonumber(r), tonumber(g), tonumber(b)
+        if r and g and b and r == g and g == b and r >= 0 and r <= 255 then
+            if r <= 96 then saw_dark = true end
+            changed = true
+            local rr = remapChannel(r, WHITE_R)
+            local gg = remapChannel(r, WHITE_G)
+            local bbv = remapChannel(r, WHITE_B)
+            return string.format("rgb(%d,%d,%d)", rr, gg, bbv)
+        end
+        return prefix .. tostring(r) .. comma1 .. tostring(g) .. comma2 .. tostring(b) .. suffix
+    end)
+
+    transformed = transformed:gsub("([" .. "'=:%s" .. "])black([;\"'%s>/])", function(pre, post)
+        changed = true
+        saw_dark = true
+        return pre .. "#202020" .. post
+    end)
+    transformed = transformed:gsub("([" .. "'=:%s" .. "])white([;\"'%s>/])", function(pre, post)
+        changed = true
+        return pre .. "#f2f2f0" .. post
+    end)
+
+    if changed and saw_dark then return transformed end
+    return nil
+end
+
+local function transformImage(content, media, tempBase)
+    if media == "image/svg+xml" then
+        return recolorSvg(content)
+    end
+    return recolorRaster(content, media, tempBase)
+end
+
+function Epub.generate(sourcePath, targetPath)
+    local reader = Archiver.Reader:new()
+    if not reader:open(sourcePath) then
+        return false, "Could not open source EPUB."
+    end
+
+    -- Populate KOReader Archiver's entry lookup table.
+    for _ in reader:iterate() do end
+
+    local container = reader:extractToMemory("META-INF/container.xml")
+    local opfPath = containerRootfile(container)
+    if not opfPath then
+        closeQuietly(reader)
+        return false, "EPUB package document was not found."
+    end
+    opfPath = normalizePath(opfPath)
+
+    local opf = reader:extractToMemory(opfPath)
+    if not opf then
+        closeQuietly(reader)
+        return false, "EPUB package document could not be read."
+    end
+    local imageSet = imageDocuments(opf, opfPath)
+
+    local tempPath = targetPath .. ".tmp"
+    local tempImageBase = targetPath .. ".ornament.tmp"
+    os.remove(tempPath)
+    os.remove(tempImageBase .. ".png")
+    os.remove(tempImageBase .. ".jpg")
+
+    local writer = Archiver.Writer:new()
+    if not writer:open(tempPath, "epub") then
+        closeQuietly(reader)
+        return false, "Could not create soft-palette EPUB cache."
+    end
+
+    local mtime = os.time()
+    writer:setZipCompression("store")
+    if not writer:addFileFromMemory("mimetype", "application/epub+zip", mtime) then
+        closeQuietly(writer)
+        closeQuietly(reader)
+        os.remove(tempPath)
+        return false, "Could not write EPUB mimetype."
+    end
+    writer:setZipCompression("deflate")
+
+    local recolored = 0
+    for entry in reader:iterate() do
+        if entry.mode == "file" and entry.path ~= "mimetype" then
+            local content = reader:extractToMemory(entry.path)
+            if content == nil then
+                closeQuietly(writer)
+                closeQuietly(reader)
+                os.remove(tempPath)
+                return false, "Could not read EPUB entry: " .. tostring(entry.path)
+            end
+
+            local media = imageSet[normalizePath(entry.path)]
+            if media then
+                local ok, transformed = pcall(transformImage, content, media, tempImageBase)
+                if ok and transformed then
+                    content = transformed
+                    recolored = recolored + 1
+                    logger.dbg("[Burrow palette] Recolored decorative EPUB image", entry.path)
+                elseif not ok then
+                    logger.warn("[Burrow palette] Ornament transform failed", entry.path, transformed)
+                end
+            end
+
+            if not writer:addFileFromMemory(entry.path, content, mtime) then
+                closeQuietly(writer)
+                closeQuietly(reader)
+                os.remove(tempPath)
+                return false, "Could not write EPUB entry: " .. tostring(entry.path)
+            end
+        end
+    end
+
+    closeQuietly(writer)
+    closeQuietly(reader)
+    os.remove(tempImageBase .. ".png")
+    os.remove(tempImageBase .. ".jpg")
+
+    os.remove(targetPath)
+    local ok, err = os.rename(tempPath, targetPath)
+    if not ok then
+        os.remove(tempPath)
+        return false, "Could not finalize soft-palette EPUB cache: " .. tostring(err)
+    end
+
+    logger.info("[Burrow palette] Built EPUB ornament cache", recolored)
+    return true
+end
+
+function Epub.ensureCache(sourcePath)
+    local directory = Epub.cacheDirectory()
+    if not ensureDir(directory) then
+        return nil, "Could not create Burrow's soft-palette cache."
+    end
+
+    local target, err = Epub.cachePath(sourcePath)
+    if not target then return nil, err end
+    if lfs.attributes(target, "mode") == "file" then return target end
+
+    local ok, buildErr = Epub.generate(sourcePath, target)
+    if not ok then
+        os.remove(target)
+        return nil, buildErr
+    end
+    return target
+end
+
+return Epub

--- a/plugins/burrow.koplugin/burrow_version.lua
+++ b/plugins/burrow.koplugin/burrow_version.lua
@@ -1,6 +1,6 @@
 return {
-    VERSION = "0.4.3-beta.3",
-    DISPLAY_VERSION = "0.4.3-beta.3",
+    VERSION = "0.4.3-beta.4",
+    DISPLAY_VERSION = "0.4.3-beta.4",
     STORE_ENGINE_VERSION = "1.2.1",
 
     -- Burrow is tested against KOReader 2026.07.2. Older releases are blocked,

--- a/plugins/burrow.koplugin/internal_patches/2-soft-palette.lua
+++ b/plugins/burrow.koplugin/internal_patches/2-soft-palette.lua
@@ -19,6 +19,7 @@ function Module.apply()
     local CreDocument = require("document/credocument")
     local ImageWidget = require("ui/widget/imagewidget")
     local ReaderStyleTweak = require("apps/reader/modules/readerstyletweak")
+    local SoftPaletteEpub = require("burrow_soft_palette_epub")
     local logger = require("logger")
     local userpatch = require("userpatch")
 
@@ -26,6 +27,7 @@ function Module.apply()
     local BLACK_DEFAULT = 0x00
     local WHITE_SOFT = 0xF2
     local BLACK_SOFT = 0x20
+    local ORNAMENT_SETTING = "burrow_soft_palette_recolor_ornaments"
 
     local current_white = tonumber(Blitbuffer.COLOR_WHITE.a)
     local current_black = tonumber(Blitbuffer.COLOR_BLACK.a)
@@ -79,6 +81,53 @@ body {
     local function hasUserReaderPalette()
         return G_reader_settings:has("cre_background_color")
             or G_reader_settings:has("cre_background_image")
+    end
+
+    local function isEpub(path)
+        return type(path) == "string" and path:lower():match("%.epub$") ~= nil
+    end
+
+    -- Optional Kindle-like treatment for small monochrome EPUB artwork. Rather
+    -- than recoloring CRengine's final framebuffer, build a cached shadow EPUB
+    -- where only conservative ornament candidates have #000/#FFF mapped to the
+    -- same #202020/#F2F2F0 palette as the page. Large and colored images remain
+    -- byte-for-byte original. The reader-context marker prevents file-browser
+    -- cover and metadata probes from ever being redirected through this cache.
+    if not CreDocument._burrow_soft_palette_ornament_loader_v1 then
+        CreDocument._burrow_soft_palette_ornament_loader_v1 = true
+        local originalLoadDocument = CreDocument.loadDocument
+
+        function CreDocument:loadDocument(fullDocument)
+            if self._loaded
+                or fullDocument == false
+                or (self._burrow_soft_palette_reader_context ~= true
+                    and self._burrow_bionic_reader_context ~= true)
+                or not G_reader_settings:isTrue(ORNAMENT_SETTING)
+                or hasUserReaderPalette()
+                or not isEpub(self.file)
+            then
+                return originalLoadDocument(self, fullDocument)
+            end
+
+            local originalFile = self.file
+            local shadow, shadowErr = SoftPaletteEpub.ensureCache(originalFile)
+            if not shadow then
+                logger.warn("[Burrow palette] Falling back to original EPUB", shadowErr)
+                return originalLoadDocument(self, fullDocument)
+            end
+
+            self.file = shadow
+            local ok, result = pcall(originalLoadDocument, self, fullDocument)
+            self.file = originalFile
+            if not ok then error(result) end
+
+            if result then
+                self._burrow_soft_palette_ornaments_active = true
+                self._burrow_soft_palette_shadow_file = shadow
+                logger.info("[Burrow palette] Loaded ornament-adjusted EPUB")
+            end
+            return result
+        end
     end
 
     if not CreDocument._burrow_soft_palette_v5 then

--- a/plugins/burrow.koplugin/internal_patches/2-statusbar-margins-presets.lua
+++ b/plugins/burrow.koplugin/internal_patches/2-statusbar-margins-presets.lua
@@ -7,21 +7,50 @@ package.loaded[MODULE_KEY] = Module
 function Module.apply()
     if Module.applied then return true end
 
-
 -- Adjustable status-bar side margins and tap-to-cycle footer presets.
--- Keeps KOReader's native ReaderFooter content, presets, gestures and settings.
+-- Also provides Burrow's optional two-sided Reading progress footer.
+-- Keeps KOReader's native ReaderFooter lifecycle, page/progress calculations,
+-- settings, and existing footer touch zone.
 
-local ReaderFooter = require("apps/reader/modules/readerfooter")
+local BD = require("ui/bidi")
+local Blitbuffer = require("ffi/blitbuffer")
+local Device = require("device")
+local Event = require("ui/event")
+local Font = require("ui/font")
+local FrameContainer = require("ui/widget/container/framecontainer")
+local Geom = require("ui/geometry")
+local HorizontalGroup = require("ui/widget/horizontalgroup")
 local HorizontalSpan = require("ui/widget/horizontalspan")
+local LeftContainer = require("ui/widget/container/leftcontainer")
+local ReaderFooter = require("apps/reader/modules/readerfooter")
+local RightContainer = require("ui/widget/container/rightcontainer")
 local Screen = require("device").screen
 local SpinWidget = require("ui/widget/spinwidget")
+local TextWidget = require("ui/widget/textwidget")
 local UIManager = require("ui/uimanager")
+local VerticalGroup = require("ui/widget/verticalgroup")
+local Widget = require("ui/widget/widget")
+local datetime = require("datetime")
 local util = require("util")
 local _ = require("gettext")
 local T = require("ffi/util").template
 
 local DEFAULT_SIDE_MARGIN = 10
 local CURRENT_PRESET_SETTING = "footer_current_preset"
+
+local SPLIT_FOOTER_ENABLED = "burrow_reading_progress_footer_enabled"
+local SPLIT_FOOTER_LEFT = "burrow_reading_progress_footer_left"
+local SPLIT_FOOTER_RIGHT = "burrow_reading_progress_footer_right"
+local SPLIT_FOOTER_BOTTOM_INSET = "burrow_reading_progress_footer_bottom_inset"
+local SPLIT_FOOTER_HORIZONTAL_INSET = "burrow_reading_progress_footer_horizontal_inset"
+local DEFAULT_SPLIT_LEFT = "book_time"
+local DEFAULT_SPLIT_RIGHT = "percentage"
+local DEFAULT_BOTTOM_INSET = 6
+local MIN_BOTTOM_INSET = 0
+local MAX_BOTTOM_INSET = 48
+local DEFAULT_HORIZONTAL_INSET = 8
+local MIN_HORIZONTAL_INSET = 0
+local MAX_HORIZONTAL_INSET = 80
 
 -- These are stored with the rest of the native footer settings, so they are
 -- automatically included when a KOReader status-bar preset is saved.
@@ -60,13 +89,262 @@ local function applyMarginRuntimeValues(footer)
     return left, right
 end
 
--- Let KOReader build its normal footer, then replace only the two edge spans.
--- No footer content, progress calculations or callbacks are replaced.
+local function splitFooterEnabled()
+    local value = G_reader_settings:readSetting(SPLIT_FOOTER_ENABLED)
+    if value == nil then return true end
+    return value == true
+end
+
+local function getSplitChoice(key, default)
+    local value = G_reader_settings:readSetting(key)
+    if type(value) ~= "string" or value == "" then return default end
+    return value
+end
+
+local function getBottomInset()
+    local value = tonumber(G_reader_settings:readSetting(SPLIT_FOOTER_BOTTOM_INSET))
+    if value == nil then value = DEFAULT_BOTTOM_INSET end
+    return math.max(MIN_BOTTOM_INSET, math.min(MAX_BOTTOM_INSET, math.floor(value + 0.5)))
+end
+
+local function getHorizontalInset()
+    local value = tonumber(G_reader_settings:readSetting(SPLIT_FOOTER_HORIZONTAL_INSET))
+    if value == nil then value = DEFAULT_HORIZONTAL_INSET end
+    return math.max(
+        MIN_HORIZONTAL_INSET,
+        math.min(MAX_HORIZONTAL_INSET, math.floor(value + 0.5))
+    )
+end
+
+local function saveSplitChoice(key, value)
+    G_reader_settings:saveSetting(key, value)
+end
+
+local function resolveLiveFooter(footer)
+    if footer then return footer end
+    local ok, ReaderUI = pcall(require, "apps/reader/readerui")
+    local reader = ok and ReaderUI.instance or nil
+    return reader and reader.footer or nil
+end
+
+local function timeForPages(footer, pages)
+    if not footer.ui or not footer.ui.statistics or type(pages) ~= "number" then
+        return nil
+    end
+    local ok, value = pcall(footer.ui.statistics.getTimeForPages, footer.ui.statistics, pages)
+    if not ok or not value or value == "" or value == _("N/A") then return nil end
+    return value
+end
+
+local function pageText(footer)
+    if type(footer.pageno) ~= "number" or not footer.pages then return nil end
+    if footer.ui and footer.ui.pagemap and footer.ui.pagemap:wantsPageLabels() then
+        local ok1, current = pcall(footer.ui.pagemap.getCurrentPageLabel, footer.ui.pagemap, true)
+        local ok2, last = pcall(footer.ui.pagemap.getLastPageLabel, footer.ui.pagemap, true)
+        if ok1 and ok2 and current and last then
+            return T(_("Page %1 of %2"), current, last)
+        end
+    end
+    return T(_("Page %1 of %2"), footer.pageno, footer.pages)
+end
+
+local function splitValue(footer, choice)
+    if choice == "hidden" then
+        return ""
+    elseif choice == "book_time" then
+        if not footer.ui or not footer.ui.document or type(footer.pageno) ~= "number" then return nil end
+        local ok, pages = pcall(footer.ui.document.getTotalPagesLeft, footer.ui.document, footer.pageno)
+        if not ok then return nil end
+        local value = timeForPages(footer, pages)
+        return value and T(_("%1 left in book"), value) or nil
+    elseif choice == "chapter_time" then
+        if not footer.ui or not footer.ui.document or type(footer.pageno) ~= "number" then return nil end
+        local pages
+        if footer.ui.toc and type(footer.ui.toc.getChapterPagesLeft) == "function" then
+            local ok, result = pcall(footer.ui.toc.getChapterPagesLeft, footer.ui.toc, footer.pageno, true)
+            if ok then pages = result end
+        end
+        if pages == nil then
+            local ok, result = pcall(footer.ui.document.getTotalPagesLeft, footer.ui.document, footer.pageno)
+            if ok then pages = result end
+        end
+        local value = timeForPages(footer, pages)
+        return value and T(_("%1 left in chapter"), value) or nil
+    elseif choice == "page" then
+        return pageText(footer)
+    elseif choice == "percentage" then
+        local pct = tonumber(footer.percent_finished)
+        if not pct then return nil end
+        return string.format("%d%%", math.floor(pct * 100 + 0.5))
+    elseif choice == "clock" then
+        return datetime.secondsToHour(os.time(), G_reader_settings:isTrue("twelve_hour_clock"))
+    elseif choice == "battery" then
+        if not Device:hasBattery() then return nil end
+        local powerd = Device:getPowerDevice()
+        local ok, capacity = pcall(powerd.getCapacity, powerd)
+        if not ok or capacity == nil then return nil end
+        return tostring(capacity) .. "%"
+    end
+    return nil
+end
+
+local LEFT_CYCLE = { "book_time", "chapter_time", "page", "hidden" }
+local RIGHT_CYCLE = { "percentage", "page", "clock", "battery", "hidden" }
+
+local CHOICE_LABELS = {
+    book_time = _("Time left in book"),
+    chapter_time = _("Time left in chapter"),
+    page = _("Page in book"),
+    percentage = _("Percentage"),
+    clock = _("Clock"),
+    battery = _("Battery"),
+    hidden = _("Hidden"),
+}
+
+local function choiceAvailable(footer, choice)
+    if choice == "hidden" then return true end
+    if choice == "battery" then return Device:hasBattery() end
+    return splitValue(footer, choice) ~= nil
+end
+
+local function nextChoice(footer, key, cycle, default)
+    local current = getSplitChoice(key, default)
+    local index = util.arrayContains(cycle, current) or 0
+    for step = 1, #cycle do
+        local next_index = ((index - 1 + step) % #cycle) + 1
+        local candidate = cycle[next_index]
+        if choiceAvailable(footer, candidate) then
+            saveSplitChoice(key, candidate)
+            return candidate
+        end
+    end
+    return current
+end
+
+local function freeSplitWidgets(footer)
+    for _, name in ipairs({ "_burrow_left_text", "_burrow_right_text" }) do
+        local widget = footer[name]
+        if widget and widget.free then
+            pcall(widget.free, widget)
+        end
+        footer[name] = nil
+    end
+end
+
+local function makeSplitTextWidget(footer, text, max_width)
+    return TextWidget:new{
+        text = text or "",
+        face = footer.footer_text_face or Font:getFace("smallinfofont", 14),
+        bold = footer.settings and footer.settings.text_font_bold or false,
+        max_width = math.max(1, max_width),
+    }
+end
+
+local function buildSplitFooterContainer(footer)
+    if not splitFooterEnabled() then return false end
+
+    local left_margin, right_margin = getScaledMargins(footer)
+    local horizontal_inset = Screen:scaleBySize(getHorizontalInset())
+    left_margin = left_margin + horizontal_inset
+    right_margin = right_margin + horizontal_inset
+
+    local screen_w = Screen:getWidth()
+    local usable_w = math.max(2, screen_w - left_margin - right_margin)
+    local left_w = math.floor(usable_w / 2)
+    local right_w = usable_w - left_w
+    local row_h = math.max(1, footer.height or Screen:scaleBySize(24))
+    local text_pad = Screen:scaleBySize(3)
+
+    freeSplitWidgets(footer)
+    footer._burrow_left_text = makeSplitTextWidget(footer, "", left_w - 2 * text_pad)
+    footer._burrow_right_text = makeSplitTextWidget(footer, "", right_w - 2 * text_pad)
+
+    local left_cell = LeftContainer:new{
+        dimen = Geom:new{ w = left_w, h = row_h },
+        footer._burrow_left_text,
+    }
+    local right_cell = RightContainer:new{
+        dimen = Geom:new{ w = right_w, h = row_h },
+        footer._burrow_right_text,
+    }
+
+    footer.horizontal_group = HorizontalGroup:new{
+        HorizontalSpan:new{ width = left_margin },
+        left_cell,
+        right_cell,
+        HorizontalSpan:new{ width = right_margin },
+    }
+
+    footer.footer_container = LeftContainer:new{
+        dimen = Geom:new{ w = screen_w, h = row_h },
+        footer.horizontal_group,
+    }
+
+    footer.vertical_frame = VerticalGroup:new{
+        footer.footer_container,
+    }
+
+    footer.footer_content = FrameContainer:new{
+        footer.vertical_frame,
+        background = Blitbuffer.COLOR_WHITE,
+        bordersize = 0,
+        padding = 0,
+        padding_bottom = (footer.bottom_padding or 0) + Screen:scaleBySize(getBottomInset()),
+    }
+
+    local BottomContainer = require("ui/widget/container/bottomcontainer")
+    footer.footer_positioner = BottomContainer:new{
+        dimen = Geom:new{ w = screen_w, h = Screen:getHeight() },
+        footer.footer_content,
+    }
+    footer[1] = footer.footer_positioner
+    footer._burrow_split_built = true
+    return true
+end
+
+local function updateSplitFooterText(footer)
+    if not splitFooterEnabled() or not footer._burrow_split_built then return end
+    local left_choice = getSplitChoice(SPLIT_FOOTER_LEFT, DEFAULT_SPLIT_LEFT)
+    local right_choice = getSplitChoice(SPLIT_FOOTER_RIGHT, DEFAULT_SPLIT_RIGHT)
+    local left = splitValue(footer, left_choice) or ""
+    local right = splitValue(footer, right_choice) or ""
+    if footer._burrow_left_text then footer._burrow_left_text:setText(BD.auto(left)) end
+    if footer._burrow_right_text then footer._burrow_right_text:setText(BD.auto(right)) end
+    if footer.horizontal_group and footer.horizontal_group.resetLayout then
+        footer.horizontal_group:resetLayout()
+    end
+end
+
+local function ensureSplitFooterReady(footer, notify_reader)
+    if not splitFooterEnabled() then return false end
+
+    local was_visible = footer.view and footer.view.footer_visible
+    if footer.view then footer.view.footer_visible = true end
+    buildSplitFooterContainer(footer)
+
+    if footer.resetLayout then footer:resetLayout(true) end
+    updateSplitFooterText(footer)
+
+    if was_visible == false then footer.visibility_change = true end
+    if notify_reader and footer.ui and footer.ui.handleEvent then
+        footer.ui:handleEvent(Event:new("ReaderFooterVisibilityChange"))
+    end
+    return true
+end
+
+-- Let KOReader build its normal footer, then replace only the two edge spans,
+-- or the whole footer row when Reading progress footer is enabled.
 local original_updateFooterContainer = ReaderFooter.updateFooterContainer
 function ReaderFooter:updateFooterContainer()
     local left, right = applyMarginRuntimeValues(self)
     original_updateFooterContainer(self)
 
+    if splitFooterEnabled() then
+        buildSplitFooterContainer(self)
+        return
+    end
+
+    self._burrow_split_built = nil
     if self.horizontal_group then
         local count = #self.horizontal_group
         if count >= 2 then
@@ -109,11 +387,82 @@ end
 -- than two presets exist, KOReader's original mode-cycling behavior is retained.
 local original_onToggleFooterMode = ReaderFooter.onToggleFooterMode
 function ReaderFooter:onToggleFooterMode()
+    if splitFooterEnabled() then
+        return true
+    end
     local enabled = not self.settings or self.settings.statusbar_cycle_presets ~= false
     if enabled and self:cycleNamedStatusBarPreset() then
         return true
     end
     return original_onToggleFooterMode(self)
+end
+
+-- Reading progress footer uses KOReader's existing footer tap zone. No new
+-- touch zones are registered. Left and right halves cycle independently.
+local original_TapFooter = ReaderFooter.TapFooter
+function ReaderFooter:TapFooter(ges)
+    if splitFooterEnabled() and not self.view.flipping_visible and ges and ges.pos then
+        if self.settings and self.settings.lock_tap then return end
+        if ges.pos.x < Screen:getWidth() / 2 then
+            nextChoice(self, SPLIT_FOOTER_LEFT, LEFT_CYCLE, DEFAULT_SPLIT_LEFT)
+        else
+            nextChoice(self, SPLIT_FOOTER_RIGHT, RIGHT_CYCLE, DEFAULT_SPLIT_RIGHT)
+        end
+        updateSplitFooterText(self)
+        self:onUpdateFooter(true)
+        return true
+    end
+    return original_TapFooter(self, ges)
+end
+
+-- Keep both side values current whenever KOReader updates its native footer.
+local original_onUpdateFooter = ReaderFooter.onUpdateFooter
+function ReaderFooter:onUpdateFooter(force_repaint, full_repaint)
+    updateSplitFooterText(self)
+    return original_onUpdateFooter(self, force_repaint, full_repaint)
+end
+
+-- KOReader initializes ReaderFooter before the document is fully ready. v1.1
+-- could therefore force footer_visible but still leave the custom row unbuilt
+-- until the setting was toggled. Re-apply the Burrow row after KOReader's own
+-- ReaderReady lifecycle has finished and screen/document dimensions are valid.
+local original_onReaderReady = ReaderFooter.onReaderReady
+function ReaderFooter:onReaderReady(...)
+    local result = original_onReaderReady(self, ...)
+    if splitFooterEnabled() then
+        ensureSplitFooterReady(self, true)
+        -- updateFooterText is now live after native onReaderReady.
+        self:onUpdateFooter(true, true)
+    end
+    return result
+end
+
+-- KOReader's native footer mode can be "off" even while Burrow's Reading
+-- progress footer is enabled. Let KOReader do normal bookkeeping first, then
+-- keep only Burrow's custom footer visible. Disabling Burrow immediately
+-- restores KOReader's native footer visibility logic.
+local original_applyFooterMode = ReaderFooter.applyFooterMode
+function ReaderFooter:applyFooterMode(mode)
+    local result = original_applyFooterMode(self, mode)
+    if splitFooterEnabled() then
+        if self.view then self.view.footer_visible = true end
+        if not self._burrow_split_built then
+            buildSplitFooterContainer(self)
+        end
+    end
+    return result
+end
+
+-- Rebuild custom widgets when the native footer font is changed.
+local original_updateFooterFont = ReaderFooter.updateFooterFont
+function ReaderFooter:updateFooterFont(...)
+    local result = original_updateFooterFont(self, ...)
+    if splitFooterEnabled() then
+        buildSplitFooterContainer(self)
+        if self.resetLayout then self:resetLayout(true) end
+        updateSplitFooterText(self)
+    end
+    return result
 end
 
 local function showMarginSpin(footer, touchmenu_instance, key, title, update_both)
@@ -132,6 +481,8 @@ local function showMarginSpin(footer, touchmenu_instance, key, title, update_bot
                 footer.settings.statusbar_left_margin = spin.value
                 footer.settings.statusbar_right_margin = spin.value
             end
+            footer:updateFooterContainer()
+            footer:resetLayout(true)
             footer:refreshFooter(true, true)
             if touchmenu_instance then
                 touchmenu_instance:updateItems()
@@ -205,6 +556,157 @@ local function marginsMenuItem(footer)
     }
 end
 
+local function choiceMenuItems(footer, setting_key, choices, default)
+    local items = {}
+    for _, choice in ipairs(choices) do
+        if choice ~= "battery" or Device:hasBattery() then
+            local value = choice
+            table.insert(items, {
+                text = CHOICE_LABELS[value],
+                radio = true,
+                checked_func = function()
+                    return getSplitChoice(setting_key, default) == value
+                end,
+                callback = function()
+                    saveSplitChoice(setting_key, value)
+                    local live_footer = resolveLiveFooter(footer)
+                    if live_footer then
+                        updateSplitFooterText(live_footer)
+                        live_footer:onUpdateFooter(true)
+                    end
+                end,
+            })
+        end
+    end
+    return items
+end
+
+local function splitFooterMenuItem(footer)
+    return {
+        text = _("Reading progress footer"),
+        sub_item_table = {
+            {
+                text = _("Use Reading progress footer"),
+                checked_func = splitFooterEnabled,
+                callback = function()
+                    local enabled = not splitFooterEnabled()
+                    G_reader_settings:saveSetting(SPLIT_FOOTER_ENABLED, enabled)
+
+                    -- Burrow Settings may be opened from the File Manager, where
+                    -- no live ReaderFooter exists. Save the same global setting
+                    -- either way, and refresh immediately only when a reader is live.
+                    local live_footer = resolveLiveFooter(footer)
+                    if not live_footer then return end
+
+                    live_footer:applyFooterMode()
+                    live_footer:updateFooterContainer()
+                    live_footer:resetLayout(true)
+                    if enabled then
+                        ensureSplitFooterReady(live_footer, true)
+                    else
+                        live_footer._burrow_split_built = nil
+                        live_footer:applyFooterMode()
+                        if live_footer.ui and live_footer.ui.handleEvent then
+                            live_footer.ui:handleEvent(Event:new("ReaderFooterVisibilityChange"))
+                        end
+                    end
+                    live_footer:refreshFooter(true, true)
+                end,
+            },
+            {
+                text_func = function()
+                    local value = getSplitChoice(SPLIT_FOOTER_LEFT, DEFAULT_SPLIT_LEFT)
+                    return T(_("Left side: %1"), CHOICE_LABELS[value] or value)
+                end,
+                enabled_func = splitFooterEnabled,
+                sub_item_table_func = function()
+                    return choiceMenuItems(footer, SPLIT_FOOTER_LEFT, LEFT_CYCLE, DEFAULT_SPLIT_LEFT)
+                end,
+            },
+            {
+                text_func = function()
+                    local value = getSplitChoice(SPLIT_FOOTER_RIGHT, DEFAULT_SPLIT_RIGHT)
+                    return T(_("Right side: %1"), CHOICE_LABELS[value] or value)
+                end,
+                enabled_func = splitFooterEnabled,
+                sub_item_table_func = function()
+                    return choiceMenuItems(footer, SPLIT_FOOTER_RIGHT, RIGHT_CYCLE, DEFAULT_SPLIT_RIGHT)
+                end,
+            },
+            {
+                text_func = function()
+                    return T(_("Footer position: %1"), getBottomInset())
+                end,
+                help_text = _("Moves the Reading progress footer upward from the bottom edge. Increase this if the footer is too low or clipped by the screen edge."),
+                enabled_func = splitFooterEnabled,
+                keep_menu_open = true,
+                callback = function(touchmenu_instance)
+                    UIManager:show(SpinWidget:new{
+                        title_text = _("Reading progress footer position"),
+                        info_text = _("Higher values move the footer farther up from the bottom edge."),
+                        value = getBottomInset(),
+                        value_min = MIN_BOTTOM_INSET,
+                        value_max = MAX_BOTTOM_INSET,
+                        value_step = 1,
+                        value_hold_step = 5,
+                        default_value = DEFAULT_BOTTOM_INSET,
+                        keep_shown_on_apply = true,
+                        callback = function(spin)
+                            G_reader_settings:saveSetting(SPLIT_FOOTER_BOTTOM_INSET, spin.value)
+                            local live_footer = resolveLiveFooter(footer)
+                            if live_footer then
+                                ensureSplitFooterReady(live_footer, true)
+                                live_footer:refreshFooter(true, true)
+                            end
+                            if touchmenu_instance then touchmenu_instance:updateItems() end
+                        end,
+                    })
+                end,
+            },
+            {
+                text_func = function()
+                    return T(_("Horizontal inset: %1"), getHorizontalInset())
+                end,
+                help_text = _("Moves both sides of the Reading progress footer inward from the left and right screen edges without changing the normal KOReader status-bar margins."),
+                enabled_func = splitFooterEnabled,
+                keep_menu_open = true,
+                callback = function(touchmenu_instance)
+                    UIManager:show(SpinWidget:new{
+                        title_text = _("Reading progress footer horizontal inset"),
+                        info_text = _("Higher values move the left and right footer items farther inward from the screen edges."),
+                        value = getHorizontalInset(),
+                        value_min = MIN_HORIZONTAL_INSET,
+                        value_max = MAX_HORIZONTAL_INSET,
+                        value_step = 1,
+                        value_hold_step = 5,
+                        default_value = DEFAULT_HORIZONTAL_INSET,
+                        keep_shown_on_apply = true,
+                        callback = function(spin)
+                            G_reader_settings:saveSetting(
+                                SPLIT_FOOTER_HORIZONTAL_INSET,
+                                spin.value
+                            )
+                            local live_footer = resolveLiveFooter(footer)
+                            if live_footer then
+                                ensureSplitFooterReady(live_footer, true)
+                                live_footer:refreshFooter(true, true)
+                            end
+                            if touchmenu_instance then touchmenu_instance:updateItems() end
+                        end,
+                    })
+                end,
+            },
+        },
+    }
+end
+
+-- Expose the exact same settings tree to Burrow Settings. Keeping one
+-- menu factory means the Status bar path and Burrow Settings always edit the
+-- same keys with the same labels, ranges, and behavior.
+function Module.getReadingProgressSettingsMenu()
+    return splitFooterMenuItem(nil)
+end
+
 local function presetCycleMenuItems(footer)
     return {
         {
@@ -212,6 +714,9 @@ local function presetCycleMenuItems(footer)
             help_text = _("A tap loads the next named status-bar preset. With fewer than two presets, the normal KOReader status-bar tap behavior is used."),
             checked_func = function()
                 return footer.settings.statusbar_cycle_presets ~= false
+            end,
+            enabled_func = function()
+                return not splitFooterEnabled()
             end,
             callback = function()
                 footer.settings.statusbar_cycle_presets =
@@ -221,7 +726,7 @@ local function presetCycleMenuItems(footer)
         {
             text = _("Next status bar preset"),
             enabled_func = function()
-                return #getPresetNames() > 1
+                return not splitFooterEnabled() and #getPresetNames() > 1
             end,
             callback = function()
                 footer:cycleNamedStatusBarPreset()
@@ -240,6 +745,7 @@ function ReaderFooter:addToMainMenu(menu_items)
         return
     end
 
+    table.insert(sub_items, splitFooterMenuItem(self))
     table.insert(sub_items, marginsMenuItem(self))
     for _, item in ipairs(presetCycleMenuItems(self)) do
         table.insert(sub_items, item)

--- a/plugins/burrow.koplugin/internal_patches/2-zzzz-soft-palette-settings.lua
+++ b/plugins/burrow.koplugin/internal_patches/2-zzzz-soft-palette-settings.lua
@@ -19,8 +19,289 @@ function Module.apply(plugin)
 
     local BurrowLoader = require("burrow_loader")
     local BurrowSettings = require("burrow_settings")
+    local Device = require("device")
+    local SpinWidget = require("ui/widget/spinwidget")
     local UIManager = require("ui/uimanager")
     local _ = require("l10n.gettext")
+    local T = require("ffi/util").template
+
+    local ORNAMENT_SETTING = "burrow_soft_palette_recolor_ornaments"
+
+    -- Mark the real reader CreDocument before CRengine loads it. The soft
+    -- palette EPUB shadow loader checks this marker so file-browser cover and
+    -- metadata probes are never redirected through a transformed copy. Keep
+    -- this wrapper composable with Bionic Reading and the other Burrow hooks.
+    if not plugin._burrow_soft_palette_reader_context_hook then
+        plugin._burrow_soft_palette_reader_context_hook = true
+        local originalDocSettingsLoad = plugin.onDocSettingsLoad
+        function plugin:onDocSettingsLoad(docSettings, document)
+            local result
+            if originalDocSettingsLoad then
+                result = originalDocSettingsLoad(self, docSettings, document)
+            end
+            local doc = document or self.document or (self.ui and self.ui.document)
+            if doc and doc.provider == "crengine" then
+                doc._burrow_soft_palette_reader_context = true
+            end
+            return result
+        end
+    end
+
+    -- This is an experimental test overlay. Turn the new ornament treatment on
+    -- for first-time testers so reopening an EPUB immediately exercises it.
+    -- The setting remains independently switchable in Burrow Settings.
+    if G_reader_settings:readSetting(ORNAMENT_SETTING) == nil then
+        G_reader_settings:saveSetting(ORNAMENT_SETTING, true)
+    end
+
+    -- Clean duplicate Quick Settings button IDs left behind by older test
+    -- overlays. LuaSettings returns tables by reference, so mutating these
+    -- arrays in place also updates the already-loaded Quick Settings module.
+    local function dedupeOrderInPlace(order)
+        if type(order) ~= "table" then return false end
+        local seen = {}
+        local write_index = 1
+        local changed = false
+        for read_index = 1, #order do
+            local id = order[read_index]
+            if not seen[id] then
+                seen[id] = true
+                order[write_index] = id
+                write_index = write_index + 1
+            else
+                changed = true
+            end
+        end
+        for index = #order, write_index, -1 do
+            order[index] = nil
+        end
+        return changed
+    end
+
+    local function cleanQuickSettingsDuplicates()
+        local config = G_reader_settings:readSetting("rounded_quick_settings_panel")
+        if type(config) ~= "table" then return end
+        local changed = dedupeOrderInPlace(config.reader_order)
+        changed = dedupeOrderInPlace(config.filemanager_order) or changed
+        if changed then
+            G_reader_settings:saveSetting("rounded_quick_settings_panel", config)
+        end
+    end
+    cleanQuickSettingsDuplicates()
+
+    -- KOReader dims disabled icon buttons by lightening the entire icon
+    -- rectangle. That is invisible on pure white, but Burrow's softer white
+    -- makes the first/last-page chevron appear inside a pale square. Hide only
+    -- the inactive boundary chevron instead, preserving the enabled chevron and
+    -- every other TouchMenu button exactly as KOReader draws them.
+    if BurrowSettings:isFeatureEnabled("soft_palette") then
+        local TouchMenu = require("ui/widget/touchmenu")
+        if not TouchMenu._burrow_soft_palette_pager_boundary_fix then
+            TouchMenu._burrow_soft_palette_pager_boundary_fix = true
+            local original_touchmenu_update_items = TouchMenu.updateItems
+            function TouchMenu:updateItems(...)
+                local result = original_touchmenu_update_items(self, ...)
+                if self.item_table and self.item_table.panel then
+                    return result
+                end
+                if self.page_num and self.page_num > 1 and self.page then
+                    if self.page_info_left_chev then
+                        if self.page <= 1 then
+                            self.page_info_left_chev:hide()
+                        else
+                            self.page_info_left_chev:show()
+                        end
+                    end
+                    if self.page_info_right_chev then
+                        if self.page >= self.page_num then
+                            self.page_info_right_chev:hide()
+                        else
+                            self.page_info_right_chev:show()
+                        end
+                    end
+                end
+                return result
+            end
+        end
+    end
+
+    local SPLIT_FOOTER_ENABLED = "burrow_reading_progress_footer_enabled"
+    local SPLIT_FOOTER_LEFT = "burrow_reading_progress_footer_left"
+    local SPLIT_FOOTER_RIGHT = "burrow_reading_progress_footer_right"
+    local SPLIT_FOOTER_BOTTOM_INSET = "burrow_reading_progress_footer_bottom_inset"
+    local SPLIT_FOOTER_HORIZONTAL_INSET = "burrow_reading_progress_footer_horizontal_inset"
+
+    local DEFAULT_SPLIT_LEFT = "book_time"
+    local DEFAULT_SPLIT_RIGHT = "percentage"
+    local DEFAULT_BOTTOM_INSET = 6
+    local DEFAULT_HORIZONTAL_INSET = 8
+
+    local LEFT_CHOICES = { "book_time", "chapter_time", "page", "hidden" }
+    local RIGHT_CHOICES = { "percentage", "page", "clock", "battery", "hidden" }
+    local CHOICE_LABELS = {
+        book_time = _("Time left in book"),
+        chapter_time = _("Time left in chapter"),
+        page = _("Page in book"),
+        percentage = _("Percentage"),
+        clock = _("Clock"),
+        battery = _("Battery"),
+        hidden = _("Hidden"),
+    }
+
+    local function splitEnabled()
+        local value = G_reader_settings:readSetting(SPLIT_FOOTER_ENABLED)
+        if value == nil then return true end
+        return value == true
+    end
+
+    local function readChoice(key, default)
+        local value = G_reader_settings:readSetting(key)
+        if type(value) ~= "string" or value == "" then return default end
+        return value
+    end
+
+    local function readInteger(key, default, minimum, maximum)
+        local value = tonumber(G_reader_settings:readSetting(key)) or default
+        value = math.floor(value + 0.5)
+        return math.max(minimum, math.min(maximum, value))
+    end
+
+    local function liveFooter()
+        local ok, ReaderUI = pcall(require, "apps/reader/readerui")
+        local reader = ok and ReaderUI.instance or nil
+        return reader and reader.footer or nil
+    end
+
+    local function refreshLiveFooter(rebuild)
+        local footer = liveFooter()
+        if not footer then return end
+        if rebuild then
+            if type(footer.applyFooterMode) == "function" then footer:applyFooterMode() end
+            if type(footer.updateFooterContainer) == "function" then footer:updateFooterContainer() end
+            if type(footer.resetLayout) == "function" then footer:resetLayout(true) end
+        end
+        if type(footer.refreshFooter) == "function" then
+            footer:refreshFooter(true, true)
+        elseif type(footer.onUpdateFooter) == "function" then
+            footer:onUpdateFooter(true, true)
+        end
+    end
+
+    local function choiceItems(setting_key, choices, default)
+        local result = {}
+        for _, choice in ipairs(choices) do
+            if choice ~= "battery" or Device:hasBattery() then
+                local value = choice
+                result[#result + 1] = {
+                    text = CHOICE_LABELS[value],
+                    radio = true,
+                    checked_func = function()
+                        return readChoice(setting_key, default) == value
+                    end,
+                    callback = function()
+                        G_reader_settings:saveSetting(setting_key, value)
+                        refreshLiveFooter(false)
+                    end,
+                }
+            end
+        end
+        return result
+    end
+
+    local function fallbackReadingProgressMenu()
+        return {
+            text = _("Reading progress footer"),
+            sub_item_table = {
+                {
+                    text = _("Use Reading progress footer"),
+                    checked_func = splitEnabled,
+                    callback = function()
+                        G_reader_settings:saveSetting(
+                            SPLIT_FOOTER_ENABLED,
+                            not splitEnabled()
+                        )
+                        refreshLiveFooter(true)
+                    end,
+                },
+                {
+                    text_func = function()
+                        local value = readChoice(SPLIT_FOOTER_LEFT, DEFAULT_SPLIT_LEFT)
+                        return T(_("Left side: %1"), CHOICE_LABELS[value] or value)
+                    end,
+                    enabled_func = splitEnabled,
+                    sub_item_table_func = function()
+                        return choiceItems(SPLIT_FOOTER_LEFT, LEFT_CHOICES, DEFAULT_SPLIT_LEFT)
+                    end,
+                },
+                {
+                    text_func = function()
+                        local value = readChoice(SPLIT_FOOTER_RIGHT, DEFAULT_SPLIT_RIGHT)
+                        return T(_("Right side: %1"), CHOICE_LABELS[value] or value)
+                    end,
+                    enabled_func = splitEnabled,
+                    sub_item_table_func = function()
+                        return choiceItems(SPLIT_FOOTER_RIGHT, RIGHT_CHOICES, DEFAULT_SPLIT_RIGHT)
+                    end,
+                },
+                {
+                    text_func = function()
+                        return T(
+                            _("Footer position: %1"),
+                            readInteger(SPLIT_FOOTER_BOTTOM_INSET, DEFAULT_BOTTOM_INSET, 0, 48)
+                        )
+                    end,
+                    help_text = _("Moves the Reading progress footer upward from the bottom edge."),
+                    enabled_func = splitEnabled,
+                    keep_menu_open = true,
+                    callback = function(touchmenu_instance)
+                        UIManager:show(SpinWidget:new{
+                            title_text = _("Reading progress footer position"),
+                            value = readInteger(SPLIT_FOOTER_BOTTOM_INSET, DEFAULT_BOTTOM_INSET, 0, 48),
+                            value_min = 0,
+                            value_max = 48,
+                            value_step = 1,
+                            value_hold_step = 5,
+                            default_value = DEFAULT_BOTTOM_INSET,
+                            keep_shown_on_apply = true,
+                            callback = function(spin)
+                                G_reader_settings:saveSetting(SPLIT_FOOTER_BOTTOM_INSET, spin.value)
+                                refreshLiveFooter(true)
+                                if touchmenu_instance then touchmenu_instance:updateItems() end
+                            end,
+                        })
+                    end,
+                },
+                {
+                    text_func = function()
+                        return T(
+                            _("Horizontal inset: %1"),
+                            readInteger(SPLIT_FOOTER_HORIZONTAL_INSET, DEFAULT_HORIZONTAL_INSET, 0, 80)
+                        )
+                    end,
+                    help_text = _("Moves both footer items inward from the left and right screen edges."),
+                    enabled_func = splitEnabled,
+                    keep_menu_open = true,
+                    callback = function(touchmenu_instance)
+                        UIManager:show(SpinWidget:new{
+                            title_text = _("Reading progress footer horizontal inset"),
+                            value = readInteger(SPLIT_FOOTER_HORIZONTAL_INSET, DEFAULT_HORIZONTAL_INSET, 0, 80),
+                            value_min = 0,
+                            value_max = 80,
+                            value_step = 1,
+                            value_hold_step = 5,
+                            default_value = DEFAULT_HORIZONTAL_INSET,
+                            keep_shown_on_apply = true,
+                            callback = function(spin)
+                                G_reader_settings:saveSetting(SPLIT_FOOTER_HORIZONTAL_INSET, spin.value)
+                                refreshLiveFooter(true)
+                                if touchmenu_instance then touchmenu_instance:updateItems() end
+                            end,
+                        })
+                    end,
+                },
+            },
+        }
+    end
 
     local original_add_to_main_menu = plugin.addToMainMenu
     function plugin:addToMainMenu(menu_items)
@@ -30,39 +311,96 @@ function Module.apply(plugin)
         local items = root and root.sub_item_table
         if type(items) ~= "table" then return end
 
+        local has_appearance = false
+        local has_reading = false
         for _, item in ipairs(items) do
             if item._burrow_soft_palette_appearance then
-                return
+                has_appearance = true
+            end
+            if item._burrow_reading_settings then
+                has_reading = true
             end
         end
 
-        local function enabled()
-            return BurrowSettings:isFeatureEnabled("soft_palette")
+        if not has_appearance then
+            local function enabled()
+                return BurrowSettings:isFeatureEnabled("soft_palette")
+            end
+
+            local appearance = {
+                text = _("Appearance"),
+                _burrow_soft_palette_appearance = true,
+                sub_item_table = {
+                    {
+                        text = _("Use softer black and white"),
+                        help_text = _("Use Burrow's softer neutral white and black instead of KOReader's pure white and black. Night mode uses KOReader's native inversion. Restart required."),
+                        checked_func = enabled,
+                        callback = function()
+                            local new_enabled = not enabled()
+                            BurrowSettings:setFeatureEnabled("soft_palette", new_enabled)
+                            if new_enabled then
+                                BurrowLoader:clearQuarantine("soft_palette")
+                            end
+                            UIManager:askForRestart()
+                        end,
+                    },
+                    {
+                        text = _("Recolor decorative book elements"),
+                        help_text = _("For EPUB books, recolor only small monochrome images and simple SVG ornaments to match Burrow's soft page colors. Covers, large images, and colored artwork are left unchanged. Reopen the book after changing this setting."),
+                        checked_func = function()
+                            return G_reader_settings:isTrue(ORNAMENT_SETTING)
+                        end,
+                        enabled_func = enabled,
+                        callback = function()
+                            G_reader_settings:saveSetting(
+                                ORNAMENT_SETTING,
+                                not G_reader_settings:isTrue(ORNAMENT_SETTING)
+                            )
+                            if type(G_reader_settings.flush) == "function" then
+                                G_reader_settings:flush()
+                            end
+                        end,
+                    },
+                },
+            }
+            table.insert(items, math.min(2, #items + 1), appearance)
         end
 
-        local appearance = {
-            text = _("Appearance"),
-            _burrow_soft_palette_appearance = true,
-            sub_item_table = {
-                {
-                    text = _("Use softer black and white"),
-                    help_text = _("Use Burrow's softer neutral white and black instead of KOReader's pure white and black. Night mode uses KOReader's native inversion. Restart required."),
-                    checked_func = enabled,
-                    callback = function()
-                        local new_enabled = not enabled()
-                        BurrowSettings:setFeatureEnabled("soft_palette", new_enabled)
-                        if new_enabled then
-                            BurrowLoader:clearQuarantine("soft_palette")
-                        end
-                        UIManager:askForRestart()
-                    end,
-                },
-            },
-        }
+        if not has_reading then
+            local reading_progress
+            local status_module = package.loaded[
+                "burrow.internal.2_statusbar_margins_presets"
+            ]
+            if status_module
+                and type(status_module.getReadingProgressSettingsMenu) == "function"
+            then
+                reading_progress = status_module.getReadingProgressSettingsMenu()
+            end
+            -- The Reading section should never silently disappear just because
+            -- another module was not discoverable at menu-build time.
+            reading_progress = reading_progress or fallbackReadingProgressMenu()
 
-        -- Burrow Settings currently begins with Library. Appearance belongs
-        -- immediately after it, before Navigation and the functional sections.
-        table.insert(items, math.min(2, #items + 1), appearance)
+            local reading = {
+                text = _("Reading"),
+                _burrow_reading_settings = true,
+                sub_item_table = { reading_progress },
+            }
+
+            local insert_at = #items + 1
+            for index, item in ipairs(items) do
+                if item.text == _("Quick settings") then
+                    insert_at = index + 1
+                    break
+                elseif item.text == _("Store")
+                    or item.text == _("Store unavailable")
+                    or item.text == _("Advanced")
+                then
+                    insert_at = index
+                    break
+                end
+            end
+            table.insert(items, insert_at, reading)
+        end
     end
 
     Module.applied = true


### PR DESCRIPTION
Promote the current Burrow 0.4.3 test work into the prerelease line.

Changes:
- add the two-sided Reading progress footer with persistent left/right choices
- initialize the Reading progress footer reliably when a book opens
- add adjustable vertical position and horizontal inset controls
- expose the same Reading progress footer controls under Burrow Settings > Reading
- clean duplicate Quick Settings button IDs left behind by prior test builds
- hide inactive TouchMenu boundary chevrons so the soft palette does not expose pale square backgrounds
- add optional Kindle-like recoloring for small monochrome EPUB ornaments while leaving covers, large images, and colored artwork untouched
- keep ornament recoloring in a cached shadow EPUB so original books are never modified
- bump prerelease version to 0.4.3-beta.4

Validation before publication:
- the four v1.7 implementation files match the local test overlay byte-for-byte by Git blob SHA
- all four Lua files parse successfully with texlua
- the v1.7 overlay ZIP passes unzip integrity validation
- the beta.4 branch is exactly five intended file changes ahead of the current prerelease branch

Stable main remains on 0.4.2. This PR targets only the prerelease branch.