### PR TITLE
Burrow 0.4.3-beta.9 sleep cover menu fix

### DIFF
--- a/plugins/burrow.koplugin/burrow_sleep_cover_crop.lua
+++ b/plugins/burrow.koplugin/burrow_sleep_cover_crop.lua
@@ -9,74 +9,7 @@ package.loaded[MODULE_KEY] = Module
 
 local SETTING = "burrow_screensaver_crop_cover_to_fill"
 
-local function makeSettingsItem(_)
-    return {
-        text = _("Crop sleep-screen book cover to fill"),
-        help_text = _("Scale the current book cover proportionally until the sleep screen is completely filled, then crop the excess from the edges. This avoids stretching or distorting the cover."),
-        _burrow_sleep_cover_crop_setting = true,
-        checked_func = function()
-            return G_reader_settings:isTrue(SETTING)
-        end,
-        callback = function()
-            G_reader_settings:saveSetting(
-                SETTING,
-                not G_reader_settings:isTrue(SETTING)
-            )
-            if type(G_reader_settings.flush) == "function" then
-                G_reader_settings:flush()
-            end
-        end,
-    }
-end
-
-local function attachBurrowSettings(plugin)
-    if type(plugin) ~= "table"
-        or plugin._burrow_sleep_cover_settings_patched
-        or type(plugin.addToMainMenu) ~= "function"
-    then
-        return
-    end
-
-    plugin._burrow_sleep_cover_settings_patched = true
-    local original_add_to_main_menu = plugin.addToMainMenu
-    local _ = require("l10n.gettext")
-
-    function plugin:addToMainMenu(menu_items)
-        original_add_to_main_menu(self, menu_items)
-
-        local root = menu_items and menu_items.filemanager_display_mode
-        local items = root and root.sub_item_table
-        if type(items) ~= "table" then return end
-
-        local appearance
-        for _, item in ipairs(items) do
-            if type(item) == "table"
-                and (item._burrow_soft_palette_appearance or item.text == _("Appearance"))
-            then
-                appearance = item
-                break
-            end
-        end
-
-        local appearance_items = appearance and appearance.sub_item_table
-        if type(appearance_items) ~= "table" then return end
-
-        for _, item in ipairs(appearance_items) do
-            if type(item) == "table" and item._burrow_sleep_cover_crop_setting then
-                return
-            end
-        end
-
-        table.insert(appearance_items, makeSettingsItem(_))
-    end
-end
-
-function Module.apply(plugin)
-    -- Use Burrow's existing menu callback rather than modifying KOReader's
-    -- native Sleep screen menu. This keeps the setting isolated to
-    -- Burrow Settings > Appearance and avoids touching the global menu builder.
-    attachBurrowSettings(plugin)
-
+function Module.apply()
     if Module.applied then return true end
 
     local ImageWidget = require("ui/widget/imagewidget")

--- a/plugins/burrow.koplugin/burrow_version.lua
+++ b/plugins/burrow.koplugin/burrow_version.lua
@@ -1,6 +1,6 @@
 return {
-    VERSION = "0.4.3-beta.8",
-    DISPLAY_VERSION = "0.4.3-beta.8",
+    VERSION = "0.4.3-beta.9",
+    DISPLAY_VERSION = "0.4.3-beta.9",
     STORE_ENGINE_VERSION = "1.2.1",
 
     -- Burrow is tested against KOReader 2026.07.2. Older releases are blocked,

--- a/plugins/burrow.koplugin/internal_patches/2-zzzz-soft-palette-settings.lua
+++ b/plugins/burrow.koplugin/internal_patches/2-zzzz-soft-palette-settings.lua
@@ -26,6 +26,7 @@ function Module.apply(plugin)
     local T = require("ffi/util").template
 
     local ORNAMENT_SETTING = "burrow_soft_palette_recolor_ornaments"
+    local SLEEP_COVER_CROP_SETTING = "burrow_screensaver_crop_cover_to_fill"
 
     -- Mark the real reader CreDocument before CRengine loads it. The soft
     -- palette EPUB shadow loader checks this marker so file-browser cover and
@@ -311,23 +312,25 @@ function Module.apply(plugin)
         local items = root and root.sub_item_table
         if type(items) ~= "table" then return end
 
-        local has_appearance = false
+        local appearance
         local has_reading = false
         for _, item in ipairs(items) do
-            if item._burrow_soft_palette_appearance then
-                has_appearance = true
+            if type(item) == "table"
+                and (item._burrow_soft_palette_appearance or item.text == _("Appearance"))
+            then
+                appearance = item
             end
             if item._burrow_reading_settings then
                 has_reading = true
             end
         end
 
-        if not has_appearance then
-            local function enabled()
-                return BurrowSettings:isFeatureEnabled("soft_palette")
-            end
+        local function enabled()
+            return BurrowSettings:isFeatureEnabled("soft_palette")
+        end
 
-            local appearance = {
+        if not appearance then
+            appearance = {
                 text = _("Appearance"),
                 _burrow_soft_palette_appearance = true,
                 sub_item_table = {
@@ -364,6 +367,43 @@ function Module.apply(plugin)
                 },
             }
             table.insert(items, math.min(2, #items + 1), appearance)
+        end
+
+        -- The crop setting is deliberately ensured after Appearance exists,
+        -- rather than only when Appearance is created. This makes it resilient
+        -- to other Burrow wrappers reusing or pre-creating the Appearance menu.
+        local appearance_items = appearance.sub_item_table
+        if type(appearance_items) ~= "table" then
+            appearance_items = {}
+            appearance.sub_item_table = appearance_items
+        end
+
+        local has_crop = false
+        for _, item in ipairs(appearance_items) do
+            if type(item) == "table" and item._burrow_sleep_cover_crop_setting then
+                has_crop = true
+                break
+            end
+        end
+
+        if not has_crop then
+            table.insert(appearance_items, {
+                text = _("Crop sleep-screen book cover to fill"),
+                help_text = _("Scale the current book cover proportionally until the sleep screen is completely filled, then crop the excess from the edges. This avoids stretching or distorting the cover."),
+                _burrow_sleep_cover_crop_setting = true,
+                checked_func = function()
+                    return G_reader_settings:isTrue(SLEEP_COVER_CROP_SETTING)
+                end,
+                callback = function()
+                    G_reader_settings:saveSetting(
+                        SLEEP_COVER_CROP_SETTING,
+                        not G_reader_settings:isTrue(SLEEP_COVER_CROP_SETTING)
+                    )
+                    if type(G_reader_settings.flush) == "function" then
+                        G_reader_settings:flush()
+                    end
+                end,
+            })
         end
 
         if not has_reading then

--- a/plugins/burrow.koplugin/main.lua
+++ b/plugins/burrow.koplugin/main.lua
@@ -111,7 +111,7 @@ if compatibility.warning then
 end
 
 -- Early optional modules are isolated by feature. Their failure is reported by
--- the loader but does not prevent the core Burrow library from starting.
+-- the loader but does not prevent the core library from starting.
 BurrowLoader:loadEarlyModules()
 
 local Burrow = WidgetContainer:extend {

--- a/plugins/burrow.koplugin/main.lua
+++ b/plugins/burrow.koplugin/main.lua
@@ -111,7 +111,7 @@ if compatibility.warning then
 end
 
 -- Early optional modules are isolated by feature. Their failure is reported by
--- the loader but does not prevent the core library from starting.
+-- the loader but does not prevent the core Burrow library from starting.
 BurrowLoader:loadEarlyModules()
 
 local Burrow = WidgetContainer:extend {
@@ -179,7 +179,7 @@ if crop_ok
     and type(SleepCoverCrop) == "table"
     and type(SleepCoverCrop.apply) == "function"
 then
-    local apply_ok, applied, apply_error = pcall(SleepCoverCrop.apply, Burrow)
+    local apply_ok, applied, apply_error = pcall(SleepCoverCrop.apply)
     if not apply_ok or applied == false then
         logger.warn(
             burrow_debug.logprefix,


### PR DESCRIPTION
## Summary
- move the sleep-cover crop toggle into the existing Burrow Settings > Appearance owner
- ensure the crop item independently after Appearance exists, so it is not dependent on Appearance being newly created
- remove all menu mutation from the sleep-cover renderer
- restore the simple renderer startup call
- bump the prerelease version to 0.4.3-beta.9

## Safety
- no ReaderMenu/FileManagerMenu hooks
- no native KOReader sleep-screen menu mutation
- no MenuSorter changes
- crop rendering behavior itself is unchanged
- all four edited Lua files were syntax-checked locally
- the GitHub blob SHAs match the locally checked files

Stable main is not targeted by this PR.