### PR TITLE
Burrow 0.4.3-beta.11 human-readable footer time

### DIFF
--- a/plugins/burrow.koplugin/burrow_version.lua
+++ b/plugins/burrow.koplugin/burrow_version.lua
@@ -1,6 +1,6 @@
 return {
-    VERSION = "0.4.3-beta.10",
-    DISPLAY_VERSION = "0.4.3-beta.10",
+    VERSION = "0.4.3-beta.11",
+    DISPLAY_VERSION = "0.4.3-beta.11",
     STORE_ENGINE_VERSION = "1.2.1",
 
     -- Burrow is tested against KOReader 2026.07.2. Older releases are blocked,

--- a/plugins/burrow.koplugin/internal_patches/2-statusbar-margins-presets.lua
+++ b/plugins/burrow.koplugin/internal_patches/2-statusbar-margins-presets.lua
@@ -127,13 +127,41 @@ local function resolveLiveFooter(footer)
     return reader and reader.footer or nil
 end
 
+local function humanizeTimeLeft(value)
+    if type(value) ~= "string" then return value end
+
+    -- KOReader's classic statistics duration is hours:minutes (for example,
+    -- "00:01"). Only rewrite that exact shape. If KOReader returns another
+    -- duration format now or in the future, keep it untouched.
+    local hours_text, minutes_text = value:match("^(%d+):(%d%d)$")
+    local hours = tonumber(hours_text)
+    local minutes = tonumber(minutes_text)
+    if hours == nil or minutes == nil or minutes > 59 then
+        return value
+    end
+
+    local total_minutes = hours * 60 + minutes
+    if total_minutes < 1 then
+        return _("<1 min")
+    elseif total_minutes < 60 then
+        return T(_("%1 min"), total_minutes)
+    end
+
+    local whole_hours = math.floor(total_minutes / 60)
+    local remaining_minutes = total_minutes % 60
+    if remaining_minutes == 0 then
+        return T(_("%1 hr"), whole_hours)
+    end
+    return T(_("%1 hr %2 min"), whole_hours, remaining_minutes)
+end
+
 local function timeForPages(footer, pages)
     if not footer.ui or not footer.ui.statistics or type(pages) ~= "number" then
         return nil
     end
     local ok, value = pcall(footer.ui.statistics.getTimeForPages, footer.ui.statistics, pages)
     if not ok or not value or value == "" or value == _("N/A") then return nil end
-    return value
+    return humanizeTimeLeft(value)
 end
 
 local function pageText(footer)


### PR DESCRIPTION
Publishes the on-device-tested human-readable Reading progress footer time formatter as beta.11.

Changes:
- use the exact footer file from the tested beta.10 overlay
- convert only plain KOReader hours:minutes estimates such as `00:01` to compact human-readable text such as `1 min`
- preserve `left in book` / `left in chapter` wording
- pass through any duration format that does not exactly match hours:minutes
- leave KOReader statistics calculations, chapter/page lookup, footer layout, footer position, horizontal inset, taps, menus, percentage, clock, battery, and presets unchanged
- bump prerelease version to 0.4.3-beta.11

Safety verification before PR:
- current prerelease footer source blob was `1755af50e6848ad2fd03269607fa2ffaee7bc0e6`, matching the overlay base
- tested overlay ZIP SHA-256 was `8a6ac2c51f4a534579701bce2d198014ba68a91d8f7558f8c47ad7426c17ed62`
- locally syntax-checked the exact overlay footer file with `texluac -p`
- GitHub blob for the committed footer file is `9503f6addd6e94baf60d141b530f59b79e609946`, exactly matching the local tested file's Git blob SHA
- branch differs from `agent/self-updater` in exactly two files: the tested footer file and `burrow_version.lua`

Stable `main` is not targeted by this PR.