### PR TITLE
Burrow 0.4.4-beta.4 explicit ornament Night Mode fix

### DIFF
--- a/plugins/burrow.koplugin/burrow_soft_palette_epub.lua
+++ b/plugins/burrow.koplugin/burrow_soft_palette_epub.lua
@@ -7,17 +7,39 @@ local logger = require("logger")
 local util = require("util")
 
 local Epub = {
-    CACHE_VERSION = "ornaments-v4-native-grayscale",
+    CACHE_VERSION = "ornaments-v5-explicit-night",
 }
 
 local PALETTES = {
     ["pure-light"] = {
         dark = { 0x00, 0x00, 0x00 },
         light = { 0xFF, 0xFF, 0xFF },
+        force_rgb = false,
+    },
+    ["pure-night"] = {
+        -- Keep a two-level blue-channel offset across the entire grayscale
+        -- ramp. CRengine treats any r/g/b mismatch as a color pixel and
+        -- pre-inverts it in Night Mode, so the final Kindle framebuffer
+        -- inversion restores these explicit night colors instead of flipping
+        -- them back to the light palette. The offset is visually neutral on
+        -- grayscale e-ink and negligible on color screens.
+        dark = { 0xFD, 0xFD, 0xFF },
+        light = { 0x00, 0x00, 0x02 },
+        force_rgb = true,
     },
     ["soft-light"] = {
         dark = { 0x20, 0x20, 0x20 },
         light = { 0xF2, 0xF2, 0xF2 },
+        force_rgb = false,
+    },
+    ["soft-night"] = {
+        -- Match Burrow's native-inverted soft page background (#0D0D0F) and
+        -- near-#DFDFDF foreground while retaining the tiny RGB distinction
+        -- CRengine needs to preserve the explicit night image through the
+        -- final hardware/page inversion.
+        dark = { 0xDF, 0xDF, 0xE1 },
+        light = { 0x0D, 0x0D, 0x0F },
+        force_rgb = true,
     },
 }
 
@@ -282,6 +304,10 @@ local function recolorRaster(content, media, tempBase, palette)
         -- grayscale JPEG (TJSAMP_GRAY), guaranteeing r == g == b when
         -- CRengine decodes them. They will then follow the page naturally.
         local bbdump, components = out:getBufferData()
+        local jpeg_quality = palette.force_rgb and 100 or 95
+        local jpeg_subsample = palette.force_rgb
+            and ffi.C.TJSAMP_444
+            or ffi.C.TJSAMP_GRAY
         local call_ok, encoded, encode_err = pcall(
             Jpeg.encodeToFile,
             tempPath,
@@ -289,9 +315,9 @@ local function recolorRaster(content, media, tempBase, palette)
             bbdump.w,
             bbdump.h,
             components,
-            95,
+            jpeg_quality,
             bbdump.stride,
-            ffi.C.TJSAMP_GRAY
+            jpeg_subsample
         )
         if bbdump ~= out then pcall(bbdump.free, bbdump) end
         write_ok = call_ok and encoded ~= false
@@ -675,7 +701,7 @@ function Epub.generate(sourcePath, targetPath, paletteName)
         return false, "Could not finalize decorative EPUB cache: " .. tostring(err)
     end
 
-    logger.info("[Burrow ornaments] Built grayscale ornament cache", paletteName, recolored)
+    logger.info("[Burrow ornaments] Built explicit ornament palette cache", paletteName, recolored)
     return true, recolored
 end
 

--- a/plugins/burrow.koplugin/burrow_version.lua
+++ b/plugins/burrow.koplugin/burrow_version.lua
@@ -1,6 +1,6 @@
 return {
-    VERSION = "0.4.4-beta.3",
-    DISPLAY_VERSION = "0.4.4-beta.3",
+    VERSION = "0.4.4-beta.4",
+    DISPLAY_VERSION = "0.4.4-beta.4",
     STORE_ENGINE_VERSION = "1.2.1",
 
     -- Burrow is tested against KOReader 2026.07.2. Older releases are blocked,

--- a/plugins/burrow.koplugin/internal_patches/2-epub-ornaments.lua
+++ b/plugins/burrow.koplugin/internal_patches/2-epub-ornaments.lua
@@ -25,22 +25,53 @@ local function softPaletteActive(Blitbuffer)
         and tonumber(Blitbuffer.COLOR_BLACK.a) == 0x20
 end
 
+local function desiredTone(document, Screen)
+    -- If KOReader is preserving images in Night Mode (the normal/default
+    -- behavior), use Burrow's explicit night-colored ornament copy. If the user
+    -- deliberately disabled native image preservation, keep the light copy and
+    -- allow KOReader's whole-page inversion to flip it naturally.
+    if Screen.night_mode and document._nightmode_images ~= false then
+        return "night"
+    end
+    return "light"
+end
+
+function Module.desiredTone(document)
+    if type(document) ~= "table" then return nil end
+    return desiredTone(document, require("device").screen)
+end
+
+local function syncKindleNightMode(logger)
+    local sync = package.loaded["burrow.internal.2_kindle_night_sync"]
+    if type(sync) ~= "table" or type(sync.sync) ~= "function" then
+        return true
+    end
+
+    local call_ok, synced, sync_error = pcall(sync.sync)
+    if not call_ok or synced == false then
+        logger.warn(
+            "[Burrow ornaments] Kindle Night Mode synchronization failed; ornament reload cancelled",
+            call_ok and sync_error or synced
+        )
+        return false
+    end
+    return true
+end
+
 function Module.apply()
     if Module.applied then return true end
 
     local Blitbuffer = require("ffi/blitbuffer")
     local CreDocument = require("document/credocument")
     local OrnamentEpub = require("burrow_soft_palette_epub")
+    local Screen = require("device").screen
     local logger = require("logger")
 
-    -- CRengine already has the night-mode behavior we need: when KOReader's
-    -- native image-preservation option is enabled, CRengine pre-inverts only
-    -- pixels whose RGB channels differ. Exact grayscale pixels are left alone
-    -- and therefore follow the final page inversion naturally. Normalize only
-    -- Burrow's conservative ornament class to exact grayscale once at open
-    -- time, then leave Night Mode completely owned by KOReader.
-    if not CreDocument._burrow_epub_ornament_loader_v4 then
-        CreDocument._burrow_epub_ornament_loader_v4 = true
+    -- Build a shadow EPUB using the exact palette required for the current
+    -- reader state. Light and Night Mode are separate cached variants. We do
+    -- not change KOReader's Night Mode or native image-preservation setting.
+    if not CreDocument._burrow_epub_ornament_loader_v5 then
+        CreDocument._burrow_epub_ornament_loader_v5 = true
         local originalLoadDocument = CreDocument.loadDocument
 
         function CreDocument:loadDocument(fullDocument)
@@ -55,20 +86,17 @@ function Module.apply()
                 return originalLoadDocument(self, fullDocument)
             end
 
+            local tone = desiredTone(self, Screen)
+            local palette = (softPaletteActive(Blitbuffer) and "soft-" or "pure-")
+                .. tone
             local originalFile = self.file
-            local palette = softPaletteActive(Blitbuffer)
-                and "soft-light"
-                or "pure-light"
             local shadow, shadowErr, normalized = OrnamentEpub.ensureCache(
                 originalFile,
                 palette
             )
 
-            -- No qualifying ornaments, or a cache-generation failure: use the
-            -- original EPUB without changing KOReader's image behavior. Mixed
-            -- books are safe because ensureCache copies every non-qualifying
-            -- image byte-for-byte and changes only images that pass the narrow
-            -- ornament detector.
+            -- Mixed books remain safe: ensureCache copies covers, photos,
+            -- colored artwork and every non-qualifying image byte-for-byte.
             if not shadow then
                 if shadowErr then
                     logger.warn(
@@ -89,8 +117,9 @@ function Module.apply()
                 self._burrow_epub_ornaments_image_count = tonumber(normalized) or 0
                 self._burrow_epub_ornaments_shadow_file = shadow
                 self._burrow_epub_ornaments_palette = palette
+                self._burrow_epub_ornaments_tone = tone
                 logger.info(
-                    "[Burrow ornaments] Loaded grayscale-normalized EPUB shadow",
+                    "[Burrow ornaments] Loaded explicit decorative EPUB palette",
                     palette,
                     self._burrow_epub_ornaments_image_count
                 )
@@ -100,6 +129,103 @@ function Module.apply()
     end
 
     Module.applied = true
+    return true
+end
+
+function Module.attachPluginClass(plugin_class)
+    if type(plugin_class) ~= "table" then
+        return false, "Burrow plugin class is unavailable"
+    end
+    if plugin_class._burrow_epub_ornament_post_night_v1 then return true end
+    plugin_class._burrow_epub_ornament_post_night_v1 = true
+
+    local UIManager = require("ui/uimanager")
+    local Screen = require("device").screen
+    local logger = require("logger")
+    local reload_pending = false
+
+    local function scheduleReload(plugin)
+        if reload_pending then return end
+        reload_pending = true
+
+        -- Burrow plugins are registered after KOReader's DeviceListener. This
+        -- handler therefore sees ToggleNightMode/SetNightMode only after native
+        -- screen inversion and G_reader_settings have already been updated.
+        -- Defer once more to the next UI tick so the event itself fully unwinds.
+        UIManager:nextTick(function()
+            reload_pending = false
+
+            local reader = plugin and plugin.ui or nil
+            local document = reader and reader.document or nil
+            if not document
+                or reader.tearing_down
+                or document._burrow_epub_ornaments_active ~= true
+                or type(reader.reloadDocument) ~= "function"
+            then
+                return
+            end
+
+            local wanted = desiredTone(document, Screen)
+            if wanted == document._burrow_epub_ornaments_tone then return end
+
+            -- Never reload while KOReader's saved and logical states disagree.
+            -- Burrow must not repair that by changing the saved preference.
+            local logical_night = Screen.night_mode == true
+            if G_reader_settings:isTrue("night_mode") ~= logical_night then
+                logger.warn(
+                    "[Burrow ornaments] Night Mode state is not settled; ornament reload skipped"
+                )
+                return
+            end
+
+            -- Beta.3's Kindle hardware synchronization remains the authority.
+            -- Verify it immediately before the reader reload. If the hardware
+            -- state cannot be made consistent, do not risk the reload.
+            if not syncKindleNightMode(logger) then return end
+
+            local ok_reload, reload_error = pcall(
+                reader.reloadDocument,
+                reader,
+                nil,
+                true
+            )
+            if not ok_reload then
+                logger.warn(
+                    "[Burrow ornaments] Could not reload explicit night ornament palette",
+                    reload_error
+                )
+                return
+            end
+
+            -- Reader reload should not alter Night Mode. Re-verify on the next
+            -- tick anyway so a Kindle can never be left with a stale framebuffer
+            -- inversion flag because of this cosmetic feature.
+            UIManager:nextTick(function()
+                syncKindleNightMode(logger)
+            end)
+        end)
+    end
+
+    local originalToggleNightMode = plugin_class.onToggleNightMode
+    function plugin_class:onToggleNightMode(...)
+        local result
+        if originalToggleNightMode then
+            result = originalToggleNightMode(self, ...)
+        end
+        scheduleReload(self)
+        return result
+    end
+
+    local originalSetNightMode = plugin_class.onSetNightMode
+    function plugin_class:onSetNightMode(...)
+        local result
+        if originalSetNightMode then
+            result = originalSetNightMode(self, ...)
+        end
+        scheduleReload(self)
+        return result
+    end
+
     return true
 end
 

--- a/plugins/burrow.koplugin/internal_patches/2-kindle-night-sync.lua
+++ b/plugins/burrow.koplugin/internal_patches/2-kindle-night-sync.lua
@@ -9,20 +9,18 @@ local Module = {
 }
 package.loaded[MODULE_KEY] = Module
 
-function Module.apply()
-    if Module.applied then return true end
-
+function Module.sync()
     local Device = require("device")
 
     -- Kindle uses the framebuffer's hardware inversion flag for Night Mode.
-    -- KOReader keeps its own logical Screen.night_mode state separately. A
-    -- restart can therefore inherit a stale hardware flag even while KOReader's
-    -- saved/logical Night Mode is off. Android does not use this path.
+    -- KOReader keeps its own logical Screen.night_mode state separately. Keep
+    -- these synchronized without ever changing the user's saved Night Mode
+    -- preference or Device.orig_hw_nightmode. This is safe to call repeatedly,
+    -- including immediately before/after Burrow reloads an ornament shadow.
     if not Device:isKindle()
         or not Device:canHWInvert()
         or not Device:canModifyFBInfo()
     then
-        Module.applied = true
         return true
     end
 
@@ -58,10 +56,6 @@ function Module.apply()
             return false, "Kindle hardware Night Mode did not accept the requested state"
         end
 
-        -- Do not change G_reader_settings or Device.orig_hw_nightmode. KOReader
-        -- still owns the user's Night Mode setting and will restore the Kindle's
-        -- pre-KOReader hardware state when it finally exits. We only make the
-        -- hardware match KOReader's current logical state while Burrow is open.
         local UIManager = require("ui/uimanager")
         UIManager:setDirty("all", "full")
 
@@ -71,6 +65,15 @@ function Module.apply()
             logical_night
         )
     end
+
+    return true
+end
+
+function Module.apply()
+    if Module.applied then return true end
+
+    local ok, err = Module.sync()
+    if not ok then return false, err end
 
     Module.applied = true
     return true

--- a/plugins/burrow.koplugin/main.lua
+++ b/plugins/burrow.koplugin/main.lua
@@ -118,6 +118,24 @@ local Burrow = WidgetContainer:extend {
     name = "burrow",
 }
 
+-- Decorative EPUB palettes need to observe Night Mode only after KOReader's
+-- native DeviceListener has completed the transition. Burrow plugin instances
+-- are registered after DeviceListener, so attach the observer to Burrow itself
+-- instead of wrapping KOReader's Night Mode owner.
+local OrnamentModule = package.loaded["burrow.internal.2_epub_ornaments"]
+if type(OrnamentModule) == "table"
+    and type(OrnamentModule.attachPluginClass) == "function"
+then
+    local ok, err = pcall(OrnamentModule.attachPluginClass, Burrow)
+    if not ok then
+        logger.warn(
+            burrow_debug.logprefix,
+            "Decorative EPUB Night Mode observer could not attach",
+            err
+        )
+    end
+end
+
 -- Bionic Reading is loaded only with Burrow Quick Settings. When present, let
 -- it mark the actual ReaderUI document during DocSettingsLoad so its CRengine
 -- shadow-file hook never touches File Manager metadata/cover probes.


### PR DESCRIPTION
Promotes the Android-tested `0.4.4-beta.3-explicit-ornament-night-v1` overlay as beta.4.

What changed:
- builds separate light and explicit Night Mode ornament shadow EPUBs
- uses a tiny RGB distinction in Night Mode so CRengine preserves Burrow's intended ornament colors through page/framebuffer inversion
- observes ToggleNightMode and SetNightMode from Burrow after KOReader's native DeviceListener transition instead of wrapping KOReader's Night Mode owner
- reloads only when an active ornament EPUB needs a different light/night tone
- keeps beta.3 Kindle hardware Night Mode synchronization and rechecks it before and after an ornament reload
- leaves covers, photographs, colored artwork, unsupported images, and non-qualifying images unchanged

Validation:
- exact four source files match the Android-tested overlay byte-for-byte by Git blob hash
- branch is based directly on the published beta.3 beta branch
- net diff is limited to those four tested source files plus the beta.4 version bump
- Android device test passed before promotion

Stable `main` is not targeted.