### PR TITLE
Burrow 0.4.4 stable

### DIFF
--- a/plugins/burrow.koplugin/burrow_settings.lua
+++ b/plugins/burrow.koplugin/burrow_settings.lua
@@ -161,6 +161,14 @@ function BurrowSettings:getModuleManifest()
         })
     end
 
+    -- Kindle can preserve a stale hardware inversion flag across a KOReader
+    -- restart even when KOReader's logical Night Mode is light. Synchronize the
+    -- Kindle-only hardware flag before any Burrow palette/UI early module paints.
+    add("kindle_night_sync", "2-kindle-night-sync.lua", "early", {
+        filename = "2-kindle-night-sync.lua",
+        feature = "kindle_night_sync",
+    })
+
     -- Apply the shared source palette before any other early UI module builds
     -- widgets or icons. It is its own guarded feature so a palette conflict can
     -- be quarantined without disabling Quick Settings, the library, or reader.
@@ -170,6 +178,14 @@ function BurrowSettings:getModuleManifest()
             feature = "soft_palette",
         })
     end
+
+    -- Selective decorative EPUB handling is independent of the optional
+    -- soft palette. Load it before Quick Settings so its CreDocument wrapper
+    -- stays inside Bionic Reading's later shadow-file wrapper.
+    add("epub_ornaments", "2-epub-ornaments.lua", "early", {
+        filename = "2-epub-ornaments.lua",
+        feature = "epub_ornaments",
+    })
 
     if self:isFeatureEnabled("quick_settings") then
         add("quick_settings", "2-quick-settings.lua", "early", {

--- a/plugins/burrow.koplugin/burrow_soft_palette_epub.lua
+++ b/plugins/burrow.koplugin/burrow_soft_palette_epub.lua
@@ -7,11 +7,41 @@ local logger = require("logger")
 local util = require("util")
 
 local Epub = {
-    CACHE_VERSION = "ornaments-v1-f2f2f0-202020",
+    CACHE_VERSION = "ornaments-v8-spine-priority",
 }
 
-local BLACK_R, BLACK_G, BLACK_B = 0x20, 0x20, 0x20
-local WHITE_R, WHITE_G, WHITE_B = 0xF2, 0xF2, 0xF0
+local PALETTES = {
+    ["pure-light"] = {
+        dark = { 0x00, 0x00, 0x00 },
+        light = { 0xFF, 0xFF, 0xFF },
+        force_rgb = false,
+    },
+    ["pure-night"] = {
+        -- Keep a two-level blue-channel offset across the entire grayscale
+        -- ramp. CRengine treats any r/g/b mismatch as a color pixel and
+        -- pre-inverts it in Night Mode, so the final Kindle framebuffer
+        -- inversion restores these explicit night colors instead of flipping
+        -- them back to the light palette. The offset is visually neutral on
+        -- grayscale e-ink and negligible on color screens.
+        dark = { 0xFD, 0xFD, 0xFF },
+        light = { 0x00, 0x00, 0x02 },
+        force_rgb = true,
+    },
+    ["soft-light"] = {
+        dark = { 0x20, 0x20, 0x20 },
+        light = { 0xF2, 0xF2, 0xF2 },
+        force_rgb = false,
+    },
+    ["soft-night"] = {
+        -- Match Burrow's native-inverted soft page background (#0D0D0F) and
+        -- near-#DFDFDF foreground while retaining the tiny RGB distinction
+        -- CRengine needs to preserve the explicit night image through the
+        -- final hardware/page inversion.
+        dark = { 0xDF, 0xDF, 0xE1 },
+        light = { 0x0D, 0x0D, 0x0F },
+        force_rgb = true,
+    },
+}
 
 -- Keep this deliberately conservative. The goal is to catch scene-break art,
 -- chapter flourishes and other small monochrome assets without recoloring
@@ -25,6 +55,11 @@ local MAX_COLORED_SAMPLE_FRACTION = 0.02
 local MIN_EXTREME_SAMPLE_FRACTION = 0.82
 local MIN_LIGHT_SAMPLE_FRACTION = 0.20
 local MIN_DARK_SAMPLE_FRACTION = 0.002
+local ASYNC_INTERVAL = 0.01
+local ASYNC_PROFILE_JOBS = {}
+local ASYNC_CACHE_JOBS = {}
+local ASYNC_HOT_CACHE_JOBS = {}
+local PREFERRED_CACHES = {}
 
 local function dirname(path)
     return path:match("^(.*[/\\])") or ""
@@ -56,7 +91,13 @@ local function attr(tag, name)
         or tag:match(name .. "%s*=%s*'([^']*)'")
 end
 
-local function imageDocuments(opf, opfPath)
+local SUPPORTED_IMAGE_MEDIA = {
+    ["image/png"] = true,
+    ["image/jpeg"] = true,
+    ["image/svg+xml"] = true,
+}
+
+local function imageAssets(opf, opfPath)
     local result = {}
     local base = dirname(opfPath)
 
@@ -71,23 +112,167 @@ local function imageDocuments(opf, opfPath)
         local media = attr(tag, "media%-type")
         local href = attr(tag, "href")
         local properties = attr(tag, "properties") or ""
-        if href and media then
-            local supported = media == "image/png"
-                or media == "image/jpeg"
-                or media == "image/svg+xml"
-            if supported then
-                href = href:gsub("#.*$", "")
-                local path = normalizePath(base .. href)
-                local is_cover = properties:find("cover%-image") ~= nil
-                    or (epub2_cover_id and id == epub2_cover_id)
-                    or path:lower():find("cover", 1, true) ~= nil
-                if not is_cover then
-                    result[path] = media
-                end
+        if href and media and media:match("^image/") then
+            href = href:gsub("#.*$", "")
+            local path = normalizePath(base .. href)
+            local is_cover = properties:find("cover%-image") ~= nil
+                or (epub2_cover_id and id == epub2_cover_id)
+                or path:lower():find("cover", 1, true) ~= nil
+            if not is_cover then
+                result[path] = {
+                    media = media,
+                    supported = SUPPORTED_IMAGE_MEDIA[media] == true,
+                }
             end
         end
     end
     return result
+end
+
+local function imageDocuments(opf, opfPath)
+    local result = {}
+    for path, image in pairs(imageAssets(opf, opfPath)) do
+        if image.supported then
+            result[path] = image.media
+        end
+    end
+    return result
+end
+
+local XHTML_MEDIA = {
+    ["application/xhtml+xml"] = true,
+    ["text/html"] = true,
+}
+
+local function manifestItems(opf, opfPath)
+    local items = {}
+    local base = dirname(opfPath)
+    for tag in (opf or ""):gmatch("<item%s+[^>]->") do
+        local id = attr(tag, "id")
+        local href = attr(tag, "href")
+        local media = attr(tag, "media%-type")
+        if id and href then
+            href = href:gsub("#.*$", "")
+            items[id] = {
+                path = normalizePath(base .. href),
+                media = media,
+            }
+        end
+    end
+    return items
+end
+
+local function spineDocuments(opf, opfPath)
+    local manifest = manifestItems(opf, opfPath)
+    local spine = {}
+    for tag in (opf or ""):gmatch("<itemref%s+[^>]->") do
+        local idref = attr(tag, "idref")
+        local item = idref and manifest[idref] or nil
+        if item and XHTML_MEDIA[item.media] then
+            spine[#spine + 1] = item.path
+        end
+    end
+    return spine
+end
+
+local function cleanReference(ref)
+    if type(ref) ~= "string" then return nil end
+    ref = ref:gsub("&amp;", "&"):gsub("#.*$", "")
+    if ref == "" or ref:match("^%a+:") or ref:sub(1, 1) == "#" then
+        return nil
+    end
+    return ref
+end
+
+local function referencedImages(content, documentPath, imageSet)
+    local found = {}
+    if type(content) ~= "string" then return found end
+    local base = dirname(documentPath)
+
+    local function add(ref)
+        ref = cleanReference(ref)
+        if not ref then return end
+        local path = normalizePath(base .. ref)
+        if imageSet[path] then found[path] = true end
+    end
+
+    for ref in content:gmatch('[Ss][Rr][Cc]%s*=%s*"([^"]+)"') do add(ref) end
+    for ref in content:gmatch("[Ss][Rr][Cc]%s*=%s*'([^']+)'") do add(ref) end
+    for ref in content:gmatch('[Hh][Rr][Ee][Ff]%s*=%s*"([^"]+)"') do add(ref) end
+    for ref in content:gmatch("[Hh][Rr][Ee][Ff]%s*=%s*'([^']+)'") do add(ref) end
+    for ref in content:gmatch('[Xx][Ll][Ii][Nn][Kk]:[Hh][Rr][Ee][Ff]%s*=%s*"([^"]+)"') do add(ref) end
+    for ref in content:gmatch("[Xx][Ll][Ii][Nn][Kk]:[Hh][Rr][Ee][Ff]%s*=%s*'([^']+)'") do add(ref) end
+    for ref in content:gmatch('[Dd][Aa][Tt][Aa]%s*=%s*"([^"]+)"') do add(ref) end
+    for ref in content:gmatch("[Dd][Aa][Tt][Aa]%s*=%s*'([^']+)'") do add(ref) end
+    for ref in content:gmatch("[Uu][Rr][Ll]%s*%(%s*['\"]?([^)'\"]+)['\"]?%s*%)") do add(ref) end
+
+    return found
+end
+
+local function clampProgress(value)
+    value = tonumber(value) or 0
+    if value < 0 then return 0 end
+    if value > 1 then return 1 end
+    return value
+end
+
+local function spineCenter(progress, count)
+    if count <= 1 then return 1 end
+    local center = math.floor(clampProgress(progress) * count) + 1
+    if center > count then center = count end
+    if center < 1 then center = 1 end
+    return center
+end
+
+local function priorityIndices(count, center, radius)
+    local result = {}
+    if count <= 0 then return result end
+    radius = math.max(0, tonumber(radius) or 0)
+    result[#result + 1] = center
+    for distance = 1, radius do
+        local ahead = center + distance
+        local behind = center - distance
+        if ahead <= count then result[#result + 1] = ahead end
+        if behind >= 1 then result[#result + 1] = behind end
+    end
+    return result
+end
+
+local function hotWindow(reader, opf, opfPath, imageSet, progress, radius, cooperate)
+    local spine = spineDocuments(opf, opfPath)
+    local total = #spine
+    if total == 0 then
+        return {}, { center = 0, total_spine = 0, radius = radius or 0 }
+    end
+
+    local center = spineCenter(progress, total)
+    local indices = priorityIndices(total, center, radius or 2)
+    local images = {}
+    local ordered_images = {}
+    local ordered_sections = {}
+
+    for _, index in ipairs(indices) do
+        local path = spine[index]
+        ordered_sections[#ordered_sections + 1] = path
+        local content = reader:extractToMemory(path)
+        if content then
+            for imagePath in pairs(referencedImages(content, path, imageSet)) do
+                if not images[imagePath] then
+                    images[imagePath] = true
+                    ordered_images[#ordered_images + 1] = imagePath
+                end
+            end
+        end
+        if cooperate then cooperate() end
+    end
+
+    return images, {
+        center = center,
+        total_spine = total,
+        radius = radius or 2,
+        ordered_sections = ordered_sections,
+        ordered_images = ordered_images,
+    }
 end
 
 local function closeQuietly(object)
@@ -100,6 +285,10 @@ local function ensureDir(path)
     return ok or lfs.attributes(path, "mode") == "directory"
 end
 
+local function paletteFor(name)
+    return PALETTES[name]
+end
+
 function Epub.cacheDirectory()
     local root
     if type(DataStorage.getFullDataDir) == "function" then
@@ -109,10 +298,9 @@ function Epub.cacheDirectory()
     return root .. "/cache/burrow-soft-palette"
 end
 
-function Epub.cachePath(source)
+local function sourceIdentity(source)
     local checksum = util.partialMD5(source)
-    if not checksum then return nil, "Could not identify this EPUB." end
-
+    if not checksum then return nil end
     local attrs = lfs.attributes(source) or {}
     local identity = table.concat({
         tostring(checksum),
@@ -120,8 +308,148 @@ function Epub.cachePath(source)
         tostring(attrs.modification or ""),
         Epub.CACHE_VERSION,
     }, "-")
-    identity = identity:gsub("[^%w%-_%.]", "_")
-    return Epub.cacheDirectory() .. "/" .. identity .. ".epub"
+    return identity:gsub("[^%w%-_%.]", "_")
+end
+
+local function preferenceKey(source, paletteName)
+    return tostring(source or "") .. "\0" .. tostring(paletteName or "")
+end
+
+function Epub.setPreferredCache(source, paletteName, path, count, meta)
+    if not source or not paletteName then return false end
+    if not path then
+        PREFERRED_CACHES[preferenceKey(source, paletteName)] = nil
+        return true
+    end
+    PREFERRED_CACHES[preferenceKey(source, paletteName)] = {
+        path = path,
+        count = tonumber(count) or 0,
+        meta = meta,
+    }
+    return true
+end
+
+function Epub.preferredCache(source, paletteName)
+    local preferred = PREFERRED_CACHES[preferenceKey(source, paletteName)]
+    if not preferred then return nil, nil, nil end
+    if lfs.attributes(preferred.path, "mode") ~= "file" then
+        PREFERRED_CACHES[preferenceKey(source, paletteName)] = nil
+        return nil, nil, nil
+    end
+    return preferred.path, preferred.count, preferred.meta
+end
+
+local function hotBucket(progress)
+    return math.floor(clampProgress(progress) * 1000 + 0.5)
+end
+
+function Epub.hotCachePath(source, paletteName, progress, radius)
+    if not paletteFor(paletteName) then
+        return nil, "Unknown decorative EPUB palette: " .. tostring(paletteName)
+    end
+    local identity = sourceIdentity(source)
+    if not identity then return nil, "Could not identify this EPUB." end
+    radius = math.max(0, tonumber(radius) or 2)
+    return string.format(
+        "%s/%s-%s-hot-%04d-r%d.epub",
+        Epub.cacheDirectory(),
+        identity,
+        paletteName,
+        hotBucket(progress),
+        radius
+    )
+end
+
+local function hotMetaPath(targetPath)
+    return targetPath .. ".hotmeta"
+end
+
+local function writeHotMeta(path, meta)
+    if not path or type(meta) ~= "table" then return false end
+    local file = io.open(path, "w")
+    if not file then return false end
+    file:write(
+        tostring(meta.center or 0), "|",
+        tostring(meta.total_spine or 0), "|",
+        tostring(meta.radius or 0), "\n"
+    )
+    file:close()
+    return true
+end
+
+local function readHotMeta(path)
+    local file = path and io.open(path, "r") or nil
+    if not file then return nil end
+    local line = file:read("*l")
+    file:close()
+    if not line then return nil end
+    local center, total, radius = line:match("^(%d+)|(%d+)|(%d+)$")
+    center, total, radius = tonumber(center), tonumber(total), tonumber(radius)
+    if not center or not total or not radius then return nil end
+    return { center = center, total_spine = total, radius = radius }
+end
+
+function Epub.cachePath(source, paletteName)
+    if not paletteFor(paletteName) then
+        return nil, "Unknown decorative EPUB palette: " .. tostring(paletteName)
+    end
+
+    local identity = sourceIdentity(source)
+    if not identity then return nil, "Could not identify this EPUB." end
+    return Epub.cacheDirectory() .. "/" .. identity .. "-" .. paletteName .. ".epub"
+end
+
+local function profilePath(source)
+    local identity = sourceIdentity(source)
+    if not identity then return nil end
+    return Epub.cacheDirectory() .. "/" .. identity .. ".profile"
+end
+
+local function readProfile(path)
+    if not path then return nil end
+    local file = io.open(path, "r")
+    if not file then return nil end
+    local line = file:read("*l")
+    file:close()
+    if not line then return nil end
+    local images, eligible = line:match("^(%d+)|(%d+)$")
+    images, eligible = tonumber(images), tonumber(eligible)
+    if not images or not eligible then return nil end
+    return {
+        image_count = images,
+        eligible_count = eligible,
+        all_eligible = images > 0 and images == eligible,
+    }
+end
+
+local function writeProfile(path, profile)
+    if not path or type(profile) ~= "table" then return false end
+    local file = io.open(path, "w")
+    if not file then return false end
+    file:write(tostring(profile.image_count or 0), "|", tostring(profile.eligible_count or 0), "\n")
+    file:close()
+    return true
+end
+
+local function countPath(targetPath)
+    return targetPath .. ".count"
+end
+
+local function readRecoloredCount(path)
+    local file = io.open(path, "r")
+    if not file then return nil end
+    local value = tonumber(file:read("*l"))
+    file:close()
+    if not value or value < 0 then return nil end
+    return math.floor(value)
+end
+
+local function writeRecoloredCount(path, count)
+    local file = io.open(path, "w")
+    if not file then return false end
+    file:write(tostring(count), "\n")
+    file:close()
+    return true
 end
 
 local function visibleChannel(channel, alpha)
@@ -146,7 +474,7 @@ local function luminance(r, g, b)
     return math.floor((77 * r + 150 * g + 29 * b + 128) / 256)
 end
 
-local function isSmallMonochromeRaster(bb)
+local function isSmallMonochromeRaster(bb, cooperate)
     local w, h = bb:getWidth(), bb:getHeight()
     if w < 4 or h < 4 then return false end
     if w > MAX_RASTER_DIMENSION or h > MAX_RASTER_DIMENSION then return false end
@@ -156,6 +484,7 @@ local function isSmallMonochromeRaster(bb)
     local step = math.max(1, math.floor(math.sqrt(area / SAMPLE_TARGET)))
     local total, colored, extremes, light, dark = 0, 0, 0, 0, 0
 
+    local sampled_rows = 0
     for y = 0, h - 1, step do
         for x = 0, w - 1, step do
             local r, g, b = visibleRGB(bb, x, y)
@@ -169,6 +498,8 @@ local function isSmallMonochromeRaster(bb)
             if luma <= 96 or luma >= 200 then extremes = extremes + 1 end
             total = total + 1
         end
+        sampled_rows = sampled_rows + 1
+        if cooperate and sampled_rows % 8 == 0 then cooperate() end
     end
 
     if total == 0 then return false end
@@ -179,11 +510,12 @@ local function isSmallMonochromeRaster(bb)
     return true
 end
 
-local function remapChannel(luma, target_white)
-    return math.floor(BLACK_R + (luma * (target_white - BLACK_R) + 127) / 255)
+local function remapChannel(luma, darkTarget, lightTarget)
+    local value = darkTarget + luma * (lightTarget - darkTarget) / 255
+    return math.floor(value + 0.5)
 end
 
-local function recolorRaster(content, media, tempBase)
+local function recolorRaster(content, media, tempBase, palette, cooperate)
     if #content > MAX_COMPRESSED_BYTES then return nil end
 
     local ok, bb = pcall(
@@ -194,7 +526,7 @@ local function recolorRaster(content, media, tempBase)
     )
     if not ok or not bb then return nil end
 
-    if not isSmallMonochromeRaster(bb) then
+    if not isSmallMonochromeRaster(bb, cooperate) then
         pcall(bb.free, bb)
         return nil
     end
@@ -207,11 +539,12 @@ local function recolorRaster(content, media, tempBase)
         for x = 0, w - 1 do
             local r, g, b = visibleRGB(bb, x, y)
             local luma = luminance(r, g, b)
-            local rr = remapChannel(luma, WHITE_R)
-            local gg = remapChannel(luma, WHITE_G)
-            local bbv = remapChannel(luma, WHITE_B)
+            local rr = remapChannel(luma, palette.dark[1], palette.light[1])
+            local gg = remapChannel(luma, palette.dark[2], palette.light[2])
+            local bbv = remapChannel(luma, palette.dark[3], palette.light[3])
             out:setPixel(x, y, ColorRGB24(rr, gg, bbv))
         end
+        if cooperate and y % 6 == 0 then cooperate() end
     end
 
     local suffix = media == "image/jpeg" and ".jpg" or ".png"
@@ -220,9 +553,37 @@ local function recolorRaster(content, media, tempBase)
 
     local write_ok, write_err
     if media == "image/jpeg" then
-        write_ok, write_err = pcall(out.writeJPG, out, tempPath, 95)
+        local Jpeg = require("ffi/jpeg")
+        local ffi = require("ffi")
+
+        -- CRengine deliberately pre-inverts only *colored* image pixels in
+        -- Night Mode so photographs keep their normal appearance after the
+        -- whole page is inverted. Encode eligible JPEG ornaments as a true
+        -- grayscale JPEG (TJSAMP_GRAY), guaranteeing r == g == b when
+        -- CRengine decodes them. They will then follow the page naturally.
+        local bbdump, components = out:getBufferData()
+        local jpeg_quality = palette.force_rgb and 100 or 95
+        local jpeg_subsample = palette.force_rgb
+            and ffi.C.TJSAMP_444
+            or ffi.C.TJSAMP_GRAY
+        local call_ok, encoded, encode_err = pcall(
+            Jpeg.encodeToFile,
+            tempPath,
+            ffi.cast("uint8_t*", bbdump.data),
+            bbdump.w,
+            bbdump.h,
+            components,
+            jpeg_quality,
+            bbdump.stride,
+            jpeg_subsample
+        )
+        if bbdump ~= out then pcall(bbdump.free, bbdump) end
+        write_ok = call_ok and encoded ~= false
+        write_err = call_ok and encode_err or encoded
     else
-        write_ok, write_err = pcall(out.writePNG, out, tempPath)
+        local call_ok, encoded, encode_err = pcall(out.writePNG, out, tempPath)
+        write_ok = call_ok and encoded ~= false
+        write_err = call_ok and encode_err or encoded
     end
 
     pcall(out.free, out)
@@ -230,7 +591,7 @@ local function recolorRaster(content, media, tempBase)
 
     if not write_ok then
         os.remove(tempPath)
-        logger.warn("[Burrow palette] Could not encode recolored ornament", write_err)
+        logger.warn("[Burrow ornaments] Could not encode adjusted ornament", write_err)
         return nil
     end
 
@@ -245,14 +606,18 @@ local function recolorRaster(content, media, tempBase)
     return transformed
 end
 
-local function remapGrayValue(value)
-    local r = remapChannel(value, WHITE_R)
-    local g = remapChannel(value, WHITE_G)
-    local b = remapChannel(value, WHITE_B)
+local function remapGrayValue(value, palette)
+    local r = remapChannel(value, palette.dark[1], palette.light[1])
+    local g = remapChannel(value, palette.dark[2], palette.light[2])
+    local b = remapChannel(value, palette.dark[3], palette.light[3])
     return string.format("#%02x%02x%02x", r, g, b)
 end
 
-local function recolorSvg(content)
+local function paletteEndpoint(rgb)
+    return string.format("#%02x%02x%02x", rgb[1], rgb[2], rgb[3])
+end
+
+local function recolorSvg(content, palette)
     if #content > 100000 then return nil end
     local lower = content:lower()
     if lower:find("<image", 1, true)
@@ -290,7 +655,7 @@ local function recolorSvg(content)
         if value then
             if value <= 96 then saw_dark = true end
             changed = true
-            return remapGrayValue(value)
+            return remapGrayValue(value, palette)
         end
         return "#" .. hex
     end)
@@ -300,9 +665,9 @@ local function recolorSvg(content)
         if r and g and b and r == g and g == b and r >= 0 and r <= 255 then
             if r <= 96 then saw_dark = true end
             changed = true
-            local rr = remapChannel(r, WHITE_R)
-            local gg = remapChannel(r, WHITE_G)
-            local bbv = remapChannel(r, WHITE_B)
+            local rr = remapChannel(r, palette.dark[1], palette.light[1])
+            local gg = remapChannel(r, palette.dark[2], palette.light[2])
+            local bbv = remapChannel(r, palette.dark[3], palette.light[3])
             return string.format("rgb(%d,%d,%d)", rr, gg, bbv)
         end
         return prefix .. tostring(r) .. comma1 .. tostring(g) .. comma2 .. tostring(b) .. suffix
@@ -311,32 +676,200 @@ local function recolorSvg(content)
     transformed = transformed:gsub("([" .. "'=:%s" .. "])black([;\"'%s>/])", function(pre, post)
         changed = true
         saw_dark = true
-        return pre .. "#202020" .. post
+        return pre .. paletteEndpoint(palette.dark) .. post
     end)
     transformed = transformed:gsub("([" .. "'=:%s" .. "])white([;\"'%s>/])", function(pre, post)
         changed = true
-        return pre .. "#f2f2f0" .. post
+        return pre .. paletteEndpoint(palette.light) .. post
     end)
 
     if changed and saw_dark then return transformed end
     return nil
 end
 
-local function transformImage(content, media, tempBase)
+local function transformImage(content, media, tempBase, palette, cooperate)
     if media == "image/svg+xml" then
-        return recolorSvg(content)
+        return recolorSvg(content, palette)
     end
-    return recolorRaster(content, media, tempBase)
+    return recolorRaster(content, media, tempBase, palette, cooperate)
 end
 
-function Epub.generate(sourcePath, targetPath)
+local function isMonochromeSvgColor(value)
+    value = (value or ""):lower():match("^%s*(.-)%s*$")
+    if value == "none" or value == "transparent"
+        or value == "currentcolor" or value == "black" or value == "white"
+    then
+        return true
+    end
+
+    local hex = value:match("^#([%x]+)$")
+    if hex then
+        if #hex == 3 or #hex == 4 then
+            return hex:sub(1, 1) == hex:sub(2, 2)
+                and hex:sub(2, 2) == hex:sub(3, 3)
+        elseif #hex == 6 or #hex == 8 then
+            local r = hex:sub(1, 2)
+            local g = hex:sub(3, 4)
+            local b = hex:sub(5, 6)
+            return r == g and g == b
+        end
+        return false
+    end
+
+    local r, g, b = value:match(
+        "^rgb%s*%(%s*(%d+)%s*,%s*(%d+)%s*,%s*(%d+)%s*%)$"
+    )
+    if r then
+        r, g, b = tonumber(r), tonumber(g), tonumber(b)
+        return r == g and g == b and r >= 0 and r <= 255
+    end
+    return false
+end
+
+local function svgHasOnlyMonochromeColors(content)
+    local lower = content:lower()
+    if lower:find("rgba%s*%(") or lower:find("hsl%s*%(")
+        or lower:find("hsla%s*%(")
+    then
+        return false
+    end
+
+    for _, attribute in ipairs({ "fill", "stroke", "color" }) do
+        for value in lower:gmatch(attribute .. '%s*=%s*"([^"]*)"') do
+            if not isMonochromeSvgColor(value) then return false end
+        end
+        for value in lower:gmatch(attribute .. "%s*=%s*'([^']*)'") do
+            if not isMonochromeSvgColor(value) then return false end
+        end
+        for value in lower:gmatch(attribute .. [[%s*:%s*([^;"']+)]]) do
+            if not isMonochromeSvgColor(value) then return false end
+        end
+    end
+    return true
+end
+
+local function isEligibleImage(content, media, cooperate)
+    if media == "image/svg+xml" then
+        return svgHasOnlyMonochromeColors(content)
+            and recolorSvg(content, PALETTES["pure-light"]) ~= nil
+    end
+    if media ~= "image/png" and media ~= "image/jpeg" then
+        return false
+    end
+    if #content > MAX_COMPRESSED_BYTES then return false end
+
+    local ok, bb = pcall(
+        RenderImage.renderImageDataWithMupdf,
+        RenderImage,
+        content,
+        #content
+    )
+    if not ok or not bb then return false end
+
+    local eligible = isSmallMonochromeRaster(bb, cooperate)
+    pcall(bb.free, bb)
+    return eligible
+end
+
+local function inspectImpl(sourcePath, cooperate)
+    local reader = Archiver.Reader:new()
+    if not reader:open(sourcePath) then
+        return nil, "Could not open source EPUB."
+    end
+
+    local indexed = 0
+    for _ in reader:iterate() do
+        indexed = indexed + 1
+        if cooperate and indexed % 24 == 0 then cooperate() end
+    end
+
+    local container = reader:extractToMemory("META-INF/container.xml")
+    local opfPath = containerRootfile(container)
+    if not opfPath then
+        closeQuietly(reader)
+        return nil, "EPUB package document was not found."
+    end
+    opfPath = normalizePath(opfPath)
+
+    local opf = reader:extractToMemory(opfPath)
+    if not opf then
+        closeQuietly(reader)
+        return nil, "EPUB package document could not be read."
+    end
+
+    local assets = imageAssets(opf, opfPath)
+    local image_count = 0
+    local eligible_count = 0
+
+    for path, image in pairs(assets) do
+        image_count = image_count + 1
+        if image.supported then
+            local content = reader:extractToMemory(path)
+            if content ~= nil then
+                if cooperate then
+                    if isEligibleImage(content, image.media, cooperate) then
+                        eligible_count = eligible_count + 1
+                    end
+                else
+                    local ok, eligible = pcall(isEligibleImage, content, image.media, nil)
+                    if ok and eligible then eligible_count = eligible_count + 1 end
+                end
+            end
+        end
+        if cooperate then cooperate() end
+    end
+
+    closeQuietly(reader)
+    return {
+        image_count = image_count,
+        eligible_count = eligible_count,
+        all_eligible = image_count > 0 and eligible_count == image_count,
+    }
+end
+
+function Epub.inspect(sourcePath)
+    return inspectImpl(sourcePath, nil)
+end
+
+function Epub.peekProfile(sourcePath)
+    local directory = Epub.cacheDirectory()
+    if not ensureDir(directory) then return nil end
+    return readProfile(profilePath(sourcePath))
+end
+
+function Epub.inspectCached(sourcePath)
+    local directory = Epub.cacheDirectory()
+    if not ensureDir(directory) then
+        return nil, "Could not create Burrow's decorative EPUB cache."
+    end
+
+    local path = profilePath(sourcePath)
+    local cached = readProfile(path)
+    if cached then return cached end
+
+    local profile, err = Epub.inspect(sourcePath)
+    if profile then writeProfile(path, profile) end
+    return profile, err
+end
+
+local function generateImpl(sourcePath, targetPath, paletteName, cooperate)
+    local palette = paletteFor(paletteName)
+    if not palette then
+        return false, "Unknown decorative EPUB palette: " .. tostring(paletteName)
+    end
+
     local reader = Archiver.Reader:new()
     if not reader:open(sourcePath) then
         return false, "Could not open source EPUB."
     end
 
-    -- Populate KOReader Archiver's entry lookup table.
-    for _ in reader:iterate() do end
+    -- Populate KOReader Archiver's entry lookup table. Yield periodically in
+    -- cooperative mode so even large EPUB manifests do not monopolize the UI.
+    local indexed = 0
+    for _ in reader:iterate() do
+        indexed = indexed + 1
+        if cooperate and indexed % 24 == 0 then cooperate() end
+    end
 
     local container = reader:extractToMemory("META-INF/container.xml")
     local opfPath = containerRootfile(container)
@@ -362,7 +895,7 @@ function Epub.generate(sourcePath, targetPath)
     local writer = Archiver.Writer:new()
     if not writer:open(tempPath, "epub") then
         closeQuietly(reader)
-        return false, "Could not create soft-palette EPUB cache."
+        return false, "Could not create decorative EPUB cache."
     end
 
     local mtime = os.time()
@@ -373,7 +906,11 @@ function Epub.generate(sourcePath, targetPath)
         os.remove(tempPath)
         return false, "Could not write EPUB mimetype."
     end
-    writer:setZipCompression("deflate")
+    -- Shadow EPUBs are disposable caches. Store entries without recompressing
+    -- them so first-open processing is limited mostly to archive I/O and the
+    -- handful of ornament transforms instead of spending CPU deflating every
+    -- unchanged book resource.
+    writer:setZipCompression("store")
 
     local recolored = 0
     for entry in reader:iterate() do
@@ -388,13 +925,43 @@ function Epub.generate(sourcePath, targetPath)
 
             local media = imageSet[normalizePath(entry.path)]
             if media then
-                local ok, transformed = pcall(transformImage, content, media, tempImageBase)
-                if ok and transformed then
-                    content = transformed
-                    recolored = recolored + 1
-                    logger.dbg("[Burrow palette] Recolored decorative EPUB image", entry.path)
-                elseif not ok then
-                    logger.warn("[Burrow palette] Ornament transform failed", entry.path, transformed)
+                -- Raster transforms run the conservative monochrome detector
+                -- internally. SVGs need one extra gate because recolorSvg()
+                -- intentionally rewrites only recognized gray tokens; without
+                -- this check a mixed-color SVG could otherwise be changed only
+                -- in part. Leave any such artwork byte-for-byte untouched.
+                local safe_svg = media ~= "image/svg+xml"
+                    or svgHasOnlyMonochromeColors(content)
+                if safe_svg then
+                    local transformed
+                    if cooperate then
+                        transformed = transformImage(
+                            content,
+                            media,
+                            tempImageBase,
+                            palette,
+                            cooperate
+                        )
+                    else
+                        local ok, value = pcall(
+                            transformImage,
+                            content,
+                            media,
+                            tempImageBase,
+                            palette,
+                            nil
+                        )
+                        if ok then
+                            transformed = value
+                        else
+                            logger.warn("[Burrow ornaments] Ornament transform failed", entry.path, value)
+                        end
+                    end
+                    if transformed then
+                        content = transformed
+                        recolored = recolored + 1
+                        logger.dbg("[Burrow ornaments] Normalized decorative EPUB image", entry.path)
+                    end
                 end
             end
 
@@ -404,6 +971,170 @@ function Epub.generate(sourcePath, targetPath)
                 os.remove(tempPath)
                 return false, "Could not write EPUB entry: " .. tostring(entry.path)
             end
+            if cooperate then cooperate() end
+        end
+    end
+
+    closeQuietly(writer)
+    closeQuietly(reader)
+    os.remove(tempImageBase .. ".png")
+    os.remove(tempImageBase .. ".jpg")
+
+    if recolored == 0 then
+        os.remove(tempPath)
+        logger.dbg("[Burrow ornaments] No eligible decorative EPUB images found")
+        return true, 0
+    end
+
+    os.remove(targetPath)
+    local ok, err = os.rename(tempPath, targetPath)
+    if not ok then
+        os.remove(tempPath)
+        return false, "Could not finalize decorative EPUB cache: " .. tostring(err)
+    end
+
+    logger.info("[Burrow ornaments] Built explicit ornament palette cache", paletteName, recolored)
+    return true, recolored
+end
+
+local function generateHotImpl(sourcePath, targetPath, paletteName, progress, radius, cooperate)
+    local palette = paletteFor(paletteName)
+    if not palette then
+        return false, "Unknown decorative EPUB palette: " .. tostring(paletteName), nil
+    end
+
+    local reader = Archiver.Reader:new()
+    if not reader:open(sourcePath) then
+        return false, "Could not open source EPUB.", nil
+    end
+
+    local indexed = 0
+    for _ in reader:iterate() do
+        indexed = indexed + 1
+        if cooperate and indexed % 24 == 0 then cooperate() end
+    end
+
+    local container = reader:extractToMemory("META-INF/container.xml")
+    local opfPath = containerRootfile(container)
+    if not opfPath then
+        closeQuietly(reader)
+        return false, "EPUB package document was not found.", nil
+    end
+    opfPath = normalizePath(opfPath)
+
+    local opf = reader:extractToMemory(opfPath)
+    if not opf then
+        closeQuietly(reader)
+        return false, "EPUB package document could not be read.", nil
+    end
+
+    local imageSet = imageDocuments(opf, opfPath)
+    local hotImages, meta = hotWindow(
+        reader,
+        opf,
+        opfPath,
+        imageSet,
+        progress,
+        radius,
+        cooperate
+    )
+
+    -- Do the expensive image analysis/conversion in reading order before the
+    -- cheap whole-archive copy. This makes the current section and nearby
+    -- sections the first ornament work Burrow performs.
+    local transformedHot = {}
+    local recolored = 0
+    local tempImageBase = targetPath .. ".ornament.tmp"
+    os.remove(tempImageBase .. ".png")
+    os.remove(tempImageBase .. ".jpg")
+
+    for _, imagePath in ipairs(meta.ordered_images or {}) do
+        local media = imageSet[imagePath]
+        if media and hotImages[imagePath] then
+            local content = reader:extractToMemory(imagePath)
+            if content then
+                local safe_svg = media ~= "image/svg+xml"
+                    or svgHasOnlyMonochromeColors(content)
+                if safe_svg then
+                    local transformed
+                    if cooperate then
+                        transformed = transformImage(
+                            content,
+                            media,
+                            tempImageBase,
+                            palette,
+                            cooperate
+                        )
+                    else
+                        local ok, value = pcall(
+                            transformImage,
+                            content,
+                            media,
+                            tempImageBase,
+                            palette,
+                            nil
+                        )
+                        if ok then transformed = value end
+                    end
+                    if transformed then
+                        transformedHot[imagePath] = transformed
+                        recolored = recolored + 1
+                        logger.dbg(
+                            "[Burrow ornaments] Prepared nearby ornament first",
+                            imagePath,
+                            meta.center,
+                            meta.total_spine
+                        )
+                    end
+                end
+            end
+        end
+        if cooperate then cooperate() end
+    end
+
+    if recolored == 0 then
+        closeQuietly(reader)
+        os.remove(tempImageBase .. ".png")
+        os.remove(tempImageBase .. ".jpg")
+        return true, 0, meta
+    end
+
+    local tempPath = targetPath .. ".tmp"
+    os.remove(tempPath)
+    local writer = Archiver.Writer:new()
+    if not writer:open(tempPath, "epub") then
+        closeQuietly(reader)
+        return false, "Could not create nearby decorative EPUB cache.", meta
+    end
+
+    local mtime = os.time()
+    writer:setZipCompression("store")
+    if not writer:addFileFromMemory("mimetype", "application/epub+zip", mtime) then
+        closeQuietly(writer)
+        closeQuietly(reader)
+        os.remove(tempPath)
+        return false, "Could not write EPUB mimetype.", meta
+    end
+    writer:setZipCompression("store")
+
+    for entry in reader:iterate() do
+        if entry.mode == "file" and entry.path ~= "mimetype" then
+            local normalized = normalizePath(entry.path)
+            local content = transformedHot[normalized]
+                or reader:extractToMemory(entry.path)
+            if content == nil then
+                closeQuietly(writer)
+                closeQuietly(reader)
+                os.remove(tempPath)
+                return false, "Could not read EPUB entry: " .. tostring(entry.path), meta
+            end
+            if not writer:addFileFromMemory(entry.path, content, mtime) then
+                closeQuietly(writer)
+                closeQuietly(reader)
+                os.remove(tempPath)
+                return false, "Could not write EPUB entry: " .. tostring(entry.path), meta
+            end
+            if cooperate then cooperate() end
         end
     end
 
@@ -416,29 +1147,262 @@ function Epub.generate(sourcePath, targetPath)
     local ok, err = os.rename(tempPath, targetPath)
     if not ok then
         os.remove(tempPath)
-        return false, "Could not finalize soft-palette EPUB cache: " .. tostring(err)
+        return false, "Could not finalize nearby decorative EPUB cache: " .. tostring(err), meta
     end
 
-    logger.info("[Burrow palette] Built EPUB ornament cache", recolored)
-    return true
+    logger.info(
+        "[Burrow ornaments] Built nearby spine-priority cache",
+        paletteName,
+        recolored,
+        meta.center,
+        meta.total_spine
+    )
+    return true, recolored, meta
 end
 
-function Epub.ensureCache(sourcePath)
+function Epub.generate(sourcePath, targetPath, paletteName)
+    return generateImpl(sourcePath, targetPath, paletteName, nil)
+end
+
+function Epub.cachedResult(sourcePath, paletteName)
+    local target, err = Epub.cachePath(sourcePath, paletteName)
+    if not target then return nil, err, nil end
+    local recolored = readRecoloredCount(countPath(target))
+    if recolored == nil then return nil, nil, nil end
+    if recolored == 0 then return false, nil, 0 end
+    if lfs.attributes(target, "mode") == "file" then
+        return target, nil, recolored
+    end
+    return nil, nil, nil
+end
+
+function Epub.ensureCache(sourcePath, paletteName, knownProfile)
     local directory = Epub.cacheDirectory()
     if not ensureDir(directory) then
-        return nil, "Could not create Burrow's soft-palette cache."
+        return nil, "Could not create Burrow's decorative EPUB cache.", nil
     end
 
-    local target, err = Epub.cachePath(sourcePath)
-    if not target then return nil, err end
-    if lfs.attributes(target, "mode") == "file" then return target end
+    local profile = knownProfile
+    if not profile then
+        profile = Epub.inspectCached(sourcePath)
+    end
+    if profile and tonumber(profile.eligible_count) == 0 then
+        return nil, nil, 0
+    end
 
-    local ok, buildErr = Epub.generate(sourcePath, target)
+    local target, err = Epub.cachePath(sourcePath, paletteName)
+    if not target then return nil, err, nil end
+
+    local countFile = countPath(target)
+    local recolored = readRecoloredCount(countFile)
+    if recolored ~= nil then
+        if recolored == 0 then
+            return nil, nil, 0
+        end
+        if lfs.attributes(target, "mode") == "file" then
+            return target, nil, recolored
+        end
+        os.remove(countFile)
+    elseif lfs.attributes(target, "mode") == "file" then
+        -- A completed Burrow ornament cache always has a count marker. If it is missing,
+        -- rebuild rather than trusting a potentially interrupted cache write.
+        os.remove(target)
+    end
+
+    local ok, result = Epub.generate(sourcePath, target, paletteName)
     if not ok then
         os.remove(target)
-        return nil, buildErr
+        os.remove(countFile)
+        return nil, result, nil
     end
-    return target
+
+    recolored = tonumber(result) or 0
+    writeRecoloredCount(countFile, recolored)
+    if recolored == 0 then
+        os.remove(target)
+        return nil, nil, 0
+    end
+    return target, nil, recolored
+end
+
+
+local function scheduleCoroutine(job_table, key, co, callback)
+    local UIManager = require("ui/uimanager")
+    local existing = job_table[key]
+    if existing then
+        existing.callbacks[#existing.callbacks + 1] = callback
+        return existing
+    end
+
+    local job = { callbacks = { callback } }
+    job_table[key] = job
+
+    local function finish(a, b, c, d)
+        if job_table[key] == job then job_table[key] = nil end
+        local callbacks = job.callbacks
+        job.callbacks = {}
+        for _, cb in ipairs(callbacks) do
+            if type(cb) == "function" then
+                local ok, err = pcall(cb, a, b, c, d)
+                if not ok then logger.warn("[Burrow ornaments] Async callback failed", err) end
+            end
+        end
+    end
+
+    local function step()
+        if job_table[key] ~= job then return end
+        local ok, a, b, c, d = coroutine.resume(co)
+        if not ok then
+            finish(nil, tostring(a), nil)
+            return
+        end
+        if coroutine.status(co) == "dead" then
+            finish(a, b, c, d)
+            return
+        end
+        UIManager:scheduleIn(ASYNC_INTERVAL, step)
+    end
+
+    UIManager:nextTick(step)
+    return job
+end
+
+function Epub.inspectAsync(sourcePath, callback)
+    local cached = Epub.peekProfile(sourcePath)
+    if cached then
+        local UIManager = require("ui/uimanager")
+        UIManager:nextTick(function() callback(cached, nil) end)
+        return { completed = true }
+    end
+
+    local key = profilePath(sourcePath) or sourcePath
+    local co = coroutine.create(function()
+        local function cooperate() coroutine.yield() end
+        local profile, err = inspectImpl(sourcePath, cooperate)
+        if profile then writeProfile(profilePath(sourcePath), profile) end
+        return profile, err
+    end)
+    return scheduleCoroutine(ASYNC_PROFILE_JOBS, key, co, callback)
+end
+
+function Epub.ensureCacheAsync(sourcePath, paletteName, knownProfile, callback)
+    local directory = Epub.cacheDirectory()
+    if not ensureDir(directory) then
+        local UIManager = require("ui/uimanager")
+        UIManager:nextTick(function()
+            callback(nil, "Could not create Burrow's decorative EPUB cache.", nil)
+        end)
+        return { completed = true }
+    end
+
+    local cached, cachedErr, cachedCount = Epub.cachedResult(sourcePath, paletteName)
+    if cached ~= nil or cachedCount == 0 then
+        local UIManager = require("ui/uimanager")
+        UIManager:nextTick(function() callback(cached or nil, cachedErr, cachedCount) end)
+        return { completed = true }
+    end
+
+    local profile = knownProfile
+    if profile and tonumber(profile.eligible_count) == 0 then
+        local UIManager = require("ui/uimanager")
+        UIManager:nextTick(function() callback(nil, nil, 0) end)
+        return { completed = true }
+    end
+
+    local target, err = Epub.cachePath(sourcePath, paletteName)
+    if not target then
+        local UIManager = require("ui/uimanager")
+        UIManager:nextTick(function() callback(nil, err, nil) end)
+        return { completed = true }
+    end
+
+    local key = target
+    local co = coroutine.create(function()
+        local function cooperate() coroutine.yield() end
+        local ok, result = generateImpl(sourcePath, target, paletteName, cooperate)
+        if not ok then
+            os.remove(target)
+            os.remove(countPath(target))
+            return nil, result, nil
+        end
+        local recolored = tonumber(result) or 0
+        writeRecoloredCount(countPath(target), recolored)
+        if recolored == 0 then
+            os.remove(target)
+            return nil, nil, 0
+        end
+        return target, nil, recolored
+    end)
+    return scheduleCoroutine(ASYNC_CACHE_JOBS, key, co, callback)
+end
+
+function Epub.ensureHotCacheAsync(sourcePath, paletteName, progress, radius, callback)
+    local directory = Epub.cacheDirectory()
+    if not ensureDir(directory) then
+        local UIManager = require("ui/uimanager")
+        UIManager:nextTick(function()
+            callback(nil, "Could not create Burrow's nearby EPUB cache.", nil, nil)
+        end)
+        return { completed = true }
+    end
+
+    progress = clampProgress(progress)
+    radius = math.max(0, tonumber(radius) or 2)
+    local target, err = Epub.hotCachePath(sourcePath, paletteName, progress, radius)
+    if not target then
+        local UIManager = require("ui/uimanager")
+        UIManager:nextTick(function() callback(nil, err, nil, nil) end)
+        return { completed = true }
+    end
+
+    local recolored = readRecoloredCount(countPath(target))
+    if recolored ~= nil then
+        local meta = readHotMeta(hotMetaPath(target))
+        if recolored == 0 then
+            local UIManager = require("ui/uimanager")
+            UIManager:nextTick(function() callback(nil, nil, 0, meta) end)
+            return { completed = true }
+        end
+        if lfs.attributes(target, "mode") == "file" then
+            local UIManager = require("ui/uimanager")
+            UIManager:nextTick(function() callback(target, nil, recolored, meta) end)
+            return { completed = true }
+        end
+        os.remove(countPath(target))
+        os.remove(hotMetaPath(target))
+    elseif lfs.attributes(target, "mode") == "file" then
+        os.remove(target)
+        os.remove(hotMetaPath(target))
+    end
+
+    local key = target
+    local co = coroutine.create(function()
+        local function cooperate() coroutine.yield() end
+        local ok, result, meta = generateHotImpl(
+            sourcePath,
+            target,
+            paletteName,
+            progress,
+            radius,
+            cooperate
+        )
+        if not ok then
+            os.remove(target)
+            os.remove(countPath(target))
+            os.remove(hotMetaPath(target))
+            return nil, result, nil, meta
+        end
+
+        local count = tonumber(result) or 0
+        writeRecoloredCount(countPath(target), count)
+        if meta then writeHotMeta(hotMetaPath(target), meta) end
+        if count == 0 then
+            os.remove(target)
+            return nil, nil, 0, meta
+        end
+        return target, nil, count, meta
+    end)
+    return scheduleCoroutine(ASYNC_HOT_CACHE_JOBS, key, co, callback)
 end
 
 return Epub

--- a/plugins/burrow.koplugin/burrow_version.lua
+++ b/plugins/burrow.koplugin/burrow_version.lua
@@ -1,6 +1,6 @@
 return {
-    VERSION = "0.4.3",
-    DISPLAY_VERSION = "0.4.3",
+    VERSION = "0.4.4",
+    DISPLAY_VERSION = "0.4.4",
     STORE_ENGINE_VERSION = "1.2.1",
 
     -- Burrow is tested against KOReader 2026.07.2. Older releases are blocked,

--- a/plugins/burrow.koplugin/internal_patches/2-epub-ornaments.lua
+++ b/plugins/burrow.koplugin/internal_patches/2-epub-ornaments.lua
@@ -1,0 +1,698 @@
+local MODULE_KEY = "burrow.internal.2_epub_ornaments"
+local existing_module = package.loaded[MODULE_KEY]
+if existing_module then return existing_module end
+
+local Module = {
+    key = MODULE_KEY,
+    phase = "early",
+    filename = "2-epub-ornaments.lua",
+}
+package.loaded[MODULE_KEY] = Module
+
+local ORNAMENT_SETTING = "burrow_soft_palette_recolor_ornaments"
+
+local function isEpub(path)
+    return type(path) == "string" and path:lower():match("%.epub$") ~= nil
+end
+
+local function hasUserReaderPalette()
+    return G_reader_settings:has("cre_background_color")
+        or G_reader_settings:has("cre_background_image")
+end
+
+local function softPaletteActive(Blitbuffer)
+    return tonumber(Blitbuffer.COLOR_WHITE.a) == 0xF2
+        and tonumber(Blitbuffer.COLOR_BLACK.a) == 0x20
+end
+
+local function desiredTone(document, Screen)
+    if Screen.night_mode and document._nightmode_images ~= false then
+        return "night"
+    end
+    return "light"
+end
+
+local function paletteName(Blitbuffer, tone)
+    return (softPaletteActive(Blitbuffer) and "soft-" or "pure-") .. tone
+end
+
+local function currentFingerprint(document)
+    local parts = {}
+    if type(document) ~= "table" then return "" end
+    if type(document.getCurrentPage) == "function" then
+        local ok, page = pcall(document.getCurrentPage, document)
+        if ok then parts[#parts + 1] = tostring(page) end
+    end
+    if type(document.getCurrentPos) == "function" then
+        local ok, pos = pcall(document.getCurrentPos, document)
+        if ok then parts[#parts + 1] = tostring(pos) end
+    end
+    return table.concat(parts, ":")
+end
+
+local function currentProgress(document)
+    if type(document) ~= "table" then return 0 end
+
+    if type(document.getCurrentPage) == "function"
+        and type(document.getPageCount) == "function"
+    then
+        local ok_page, page = pcall(document.getCurrentPage, document)
+        local ok_count, count = pcall(document.getPageCount, document)
+        page, count = tonumber(page), tonumber(count)
+        if ok_page and ok_count and page and count and count > 1 then
+            local progress = (page - 1) / (count - 1)
+            if progress < 0 then return 0 end
+            if progress > 1 then return 1 end
+            return progress
+        end
+    end
+
+    if type(document.getCurrentPos) == "function"
+        and type(document.getFullHeight) == "function"
+    then
+        local ok_pos, pos = pcall(document.getCurrentPos, document)
+        local ok_height, height = pcall(document.getFullHeight, document)
+        pos, height = tonumber(pos), tonumber(height)
+        if ok_pos and ok_height and pos and height and height > 0 then
+            local progress = pos / height
+            if progress < 0 then return 0 end
+            if progress > 1 then return 1 end
+            return progress
+        end
+    end
+
+    if type(document.getProgress) == "function" then
+        local ok, progress = pcall(document.getProgress, document)
+        progress = tonumber(progress)
+        if ok and progress then
+            if progress > 1 and progress <= 100 then progress = progress / 100 end
+            if progress < 0 then return 0 end
+            if progress > 1 then return 1 end
+            return progress
+        end
+    end
+
+    return 0
+end
+
+local function hotWindowStillRelevant(document, meta)
+    if type(meta) ~= "table" then return true end
+    local total = tonumber(meta.total_spine) or 0
+    local center = tonumber(meta.center) or 0
+    local radius = math.max(1, tonumber(meta.radius) or 1)
+    if total <= 0 or center <= 0 then return true end
+
+    local current = math.floor(currentProgress(document) * total) + 1
+    if current > total then current = total end
+    if current < 1 then current = 1 end
+    return math.abs(current - center) <= radius
+end
+
+function Module.desiredTone(document)
+    if type(document) ~= "table" then return nil end
+    if document._burrow_epub_ornaments_fast_adaptive == true then
+        return "adaptive"
+    end
+    return desiredTone(document, require("device").screen)
+end
+
+local function syncKindleNightMode(logger)
+    local sync = package.loaded["burrow.internal.2_kindle_night_sync"]
+    if type(sync) ~= "table" or type(sync.sync) ~= "function" then
+        return true
+    end
+
+    local call_ok, synced, sync_error = pcall(sync.sync)
+    if not call_ok or synced == false then
+        logger.warn(
+            "[Burrow ornaments] Kindle Night Mode synchronization failed",
+            call_ok and sync_error or synced
+        )
+        return false
+    end
+    return true
+end
+
+function Module.apply()
+    if Module.applied then return true end
+
+    local Blitbuffer = require("ffi/blitbuffer")
+    local CreDocument = require("document/credocument")
+    local OrnamentEpub = require("burrow_soft_palette_epub")
+    local Screen = require("device").screen
+    local UIManager = require("ui/uimanager")
+    local logger = require("logger")
+
+    local function prepareCachesInBackground(document, originalFile, profile)
+        if type(document) ~= "table" or not isEpub(originalFile) then return end
+
+        local function start(profileValue)
+            if type(profileValue) ~= "table" then return end
+            document._burrow_epub_ornaments_profile = profileValue
+            document._burrow_epub_ornaments_source_file = originalFile
+            document._burrow_epub_ornaments_fast_adaptive_candidate =
+                profileValue.all_eligible == true and document._nightmode_images ~= false
+
+            if tonumber(profileValue.eligible_count) == 0 then
+                document._burrow_epub_ornaments_no_eligible = true
+                return
+            end
+
+            local fast = document._burrow_epub_ornaments_fast_adaptive_candidate == true
+            local firstTone = fast and "light" or desiredTone(document, Screen)
+            local firstPalette = paletteName(Blitbuffer, firstTone)
+
+            OrnamentEpub.ensureCacheAsync(
+                originalFile,
+                firstPalette,
+                profileValue,
+                function(shadow, err)
+                    if err then
+                        logger.warn("[Burrow ornaments] Background cache preparation failed", err)
+                        return
+                    end
+                    if not shadow then return end
+                    document._burrow_epub_ornaments_prepared_palette = firstPalette
+
+                    -- Mixed-image books need separate explicit light/night caches.
+                    -- Prepare the alternate tone only after the current tone is done
+                    -- so background work stays gentle while the user is reading.
+                    if not fast then
+                        local secondTone = firstTone == "night" and "light" or "night"
+                        OrnamentEpub.ensureCacheAsync(
+                            originalFile,
+                            paletteName(Blitbuffer, secondTone),
+                            profileValue,
+                            function(_, secondErr)
+                                if secondErr then
+                                    logger.warn(
+                                        "[Burrow ornaments] Alternate background cache failed",
+                                        secondErr
+                                    )
+                                end
+                            end
+                        )
+                    end
+                end
+            )
+        end
+
+        if profile then
+            start(profile)
+        else
+            OrnamentEpub.inspectAsync(originalFile, function(asyncProfile, err)
+                if err then
+                    logger.warn("[Burrow ornaments] Background preflight failed", err)
+                    return
+                end
+                start(asyncProfile)
+            end)
+        end
+    end
+
+    -- Opening a book must never wait for first-time ornament analysis or cache
+    -- generation. Use a completed cache when one already exists; otherwise open
+    -- the original EPUB immediately and prepare the cache cooperatively after the
+    -- reader has become interactive.
+    if not CreDocument._burrow_epub_ornament_loader_v7 then
+        CreDocument._burrow_epub_ornament_loader_v7 = true
+        local originalLoadDocument = CreDocument.loadDocument
+
+        function CreDocument:loadDocument(fullDocument)
+            if self._loaded
+                or fullDocument == false
+                or (self._burrow_epub_ornament_reader_context ~= true
+                    and self._burrow_bionic_reader_context ~= true)
+                or not G_reader_settings:isTrue(ORNAMENT_SETTING)
+                or hasUserReaderPalette()
+                or not isEpub(self.file)
+            then
+                return originalLoadDocument(self, fullDocument)
+            end
+
+            local originalFile = self.file
+            self._burrow_epub_ornaments_source_file = originalFile
+
+            local profile = OrnamentEpub.peekProfile(originalFile)
+            if profile and tonumber(profile.eligible_count) == 0 then
+                self._burrow_epub_ornaments_profile = profile
+                self._burrow_epub_ornaments_no_eligible = true
+                return originalLoadDocument(self, fullDocument)
+            end
+
+            local fast_adaptive = profile
+                and profile.all_eligible == true
+                and self._nightmode_images ~= false
+            local tone = fast_adaptive and "light" or desiredTone(self, Screen)
+            local palette = paletteName(Blitbuffer, tone)
+            local shadow, shadowErr, normalized
+            local hot_used = false
+            local hot_meta
+
+            if palette then
+                shadow, shadowErr, normalized = OrnamentEpub.cachedResult(
+                    originalFile,
+                    palette
+                )
+                if shadowErr then
+                    logger.warn("[Burrow ornaments] Could not inspect completed cache", shadowErr)
+                end
+
+                if shadow == nil then
+                    local preferred, preferredCount, preferredMeta =
+                        OrnamentEpub.preferredCache(originalFile, palette)
+                    if preferred then
+                        shadow = preferred
+                        normalized = preferredCount
+                        hot_meta = preferredMeta
+                        hot_used = true
+                    end
+                end
+
+                -- A hot cache may have been built before the full profile proved
+                -- that every image is adaptive-safe. If that happened, prefer the
+                -- already-prepared explicit current-tone cache for this reload
+                -- instead of discarding nearby work and reopening the original.
+                if shadow == nil and fast_adaptive then
+                    local explicitTone = desiredTone(self, Screen)
+                    local explicitPalette = paletteName(Blitbuffer, explicitTone)
+                    local preferred, preferredCount, preferredMeta =
+                        OrnamentEpub.preferredCache(originalFile, explicitPalette)
+                    if preferred then
+                        fast_adaptive = false
+                        tone = explicitTone
+                        palette = explicitPalette
+                        shadow = preferred
+                        normalized = preferredCount
+                        hot_meta = preferredMeta
+                        hot_used = true
+                    end
+                end
+            end
+
+            if shadow then
+                self.file = shadow
+                local ok, result = pcall(originalLoadDocument, self, fullDocument)
+                self.file = originalFile
+                if not ok then error(result) end
+
+                if result then
+                    self._burrow_epub_ornaments_active = true
+                    self._burrow_epub_ornaments_image_count = tonumber(normalized) or 0
+                    self._burrow_epub_ornaments_shadow_file = shadow
+                    self._burrow_epub_ornaments_palette = palette
+                    self._burrow_epub_ornaments_fast_adaptive = fast_adaptive == true
+                    self._burrow_epub_ornaments_fast_adaptive_candidate = fast_adaptive == true
+                    self._burrow_epub_ornaments_tone = fast_adaptive and "adaptive" or tone
+                    self._burrow_epub_ornaments_profile = profile
+                    self._burrow_epub_ornaments_hot = hot_used
+                    self._burrow_epub_ornaments_hot_meta = hot_meta
+                    logger.info(
+                        hot_used
+                            and "[Burrow ornaments] Loaded nearby spine-priority ornament EPUB"
+                            or (fast_adaptive
+                                and "[Burrow ornaments] Loaded cooperative adaptive ornament EPUB"
+                                or "[Burrow ornaments] Loaded cooperative explicit ornament EPUB"),
+                        palette,
+                        self._burrow_epub_ornaments_image_count
+                    )
+                end
+                return result
+            end
+
+            -- Missing profile/cache: open the original now. Background work begins
+            -- only after this call returns and yields back to KOReader's event loop.
+            local result = originalLoadDocument(self, fullDocument)
+            if result then
+                self._burrow_epub_ornaments_active = false
+                self._burrow_epub_ornaments_profile = profile
+                self._burrow_epub_ornaments_fast_adaptive_candidate = fast_adaptive == true
+                -- ReaderReady will start a spine-priority nearby cache first.
+                -- Full-book analysis begins only after that hot window is ready,
+                -- so background work cannot outrun the pages the user is reading.
+                self._burrow_epub_ornaments_needs_background = true
+            end
+            return result
+        end
+    end
+
+    -- Once a book has been loaded from the single adaptive cache, Night Mode can
+    -- switch with a normal page repaint. No EPUB swap or ReaderUI reload is needed.
+    if not CreDocument._burrow_epub_ornament_draw_v7 then
+        CreDocument._burrow_epub_ornament_draw_v7 = true
+        local originalDrawCurrentView = CreDocument.drawCurrentView
+
+        function CreDocument:drawCurrentView(...)
+            if self._burrow_epub_ornaments_fast_adaptive ~= true
+                or not Screen.night_mode
+                or self._nightmode_images == false
+            then
+                return originalDrawCurrentView(self, ...)
+            end
+
+            local currentPage
+            if type(self.getCurrentPage) == "function" then
+                local ok_page, page = pcall(self.getCurrentPage, self)
+                if ok_page then currentPage = tonumber(page) end
+            end
+            if currentPage and currentPage <= 1 then
+                return originalDrawCurrentView(self, ...)
+            end
+
+            local originalNightmodeImages = self._nightmode_images
+            self._nightmode_images = false
+            local results = { pcall(originalDrawCurrentView, self, ...) }
+            self._nightmode_images = originalNightmodeImages
+
+            local ok = table.remove(results, 1)
+            if not ok then error(results[1]) end
+            return unpack(results)
+        end
+    end
+
+    Module.applied = true
+    return true
+end
+
+function Module.attachPluginClass(plugin_class)
+    if type(plugin_class) ~= "table" then
+        return false, "Burrow plugin class is unavailable"
+    end
+    if plugin_class._burrow_epub_ornament_post_night_v4 then return true end
+    plugin_class._burrow_epub_ornament_post_night_v4 = true
+
+    local Blitbuffer = require("ffi/blitbuffer")
+    local UIManager = require("ui/uimanager")
+    local Screen = require("device").screen
+    local OrnamentEpub = require("burrow_soft_palette_epub")
+    local logger = require("logger")
+    local update_pending = false
+    local update_token = 0
+    local HOT_RADIUS = 3
+
+    local function scheduleIdleReload(plugin, token, wantedTone)
+        local stable_ticks = 0
+        local last_fingerprint
+
+        local function checkIdle()
+            if token ~= update_token then return end
+            local reader = plugin and plugin.ui or nil
+            local document = reader and reader.document or nil
+            if not document or reader.tearing_down then return end
+            if desiredTone(document, Screen) ~= wantedTone then return end
+
+            local fingerprint = currentFingerprint(document)
+            if last_fingerprint ~= nil and fingerprint ~= last_fingerprint then
+                stable_ticks = 0
+            else
+                stable_ticks = stable_ticks + 1
+            end
+            last_fingerprint = fingerprint
+
+            -- Reading always wins. Keep postponing the cache swap while the user
+            -- is moving through the book; only reload after a short stable pause.
+            if stable_ticks < 2 then
+                UIManager:scheduleIn(0.55, checkIdle)
+                return
+            end
+
+            if type(reader.reloadDocument) ~= "function" then return end
+            local ok_reload, reload_error = pcall(reader.reloadDocument, reader, nil, true)
+            if not ok_reload then
+                logger.warn("[Burrow ornaments] Could not apply nearby ornament palette", reload_error)
+                return
+            end
+            UIManager:nextTick(function()
+                syncKindleNightMode(logger)
+            end)
+        end
+
+        UIManager:scheduleIn(0.55, checkIdle)
+    end
+
+    local function startFullBackground(document, originalFile, wantedTone, knownProfile)
+        if not document or not isEpub(originalFile) then return end
+
+        local function withProfile(profile)
+            if type(profile) ~= "table" then return end
+            document._burrow_epub_ornaments_profile = profile
+            if tonumber(profile.eligible_count) == 0 then return end
+
+            local fast = profile.all_eligible == true
+                and document._nightmode_images ~= false
+            document._burrow_epub_ornaments_fast_adaptive_candidate = fast
+            local firstTone = fast and "light" or wantedTone
+            local firstPalette = paletteName(Blitbuffer, firstTone)
+
+            OrnamentEpub.ensureCacheAsync(
+                originalFile,
+                firstPalette,
+                profile,
+                function(_, firstErr)
+                    if firstErr then
+                        logger.warn("[Burrow ornaments] Full background cache failed", firstErr)
+                        return
+                    end
+
+                    -- For mixed-image books, quietly prepare the opposite tone
+                    -- after the current tone is complete. Never reload just because
+                    -- this distant/background work finished.
+                    if not fast then
+                        local secondTone = firstTone == "night" and "light" or "night"
+                        OrnamentEpub.ensureCacheAsync(
+                            originalFile,
+                            paletteName(Blitbuffer, secondTone),
+                            profile,
+                            function(_, secondErr)
+                                if secondErr then
+                                    logger.warn(
+                                        "[Burrow ornaments] Alternate full background cache failed",
+                                        secondErr
+                                    )
+                                end
+                            end
+                        )
+                    end
+                end
+            )
+        end
+
+        local profile = knownProfile
+            or document._burrow_epub_ornaments_profile
+            or OrnamentEpub.peekProfile(originalFile)
+        if profile then
+            withProfile(profile)
+        else
+            OrnamentEpub.inspectAsync(originalFile, function(asyncProfile, err)
+                if err then
+                    logger.warn("[Burrow ornaments] Deferred full-book preflight failed", err)
+                    return
+                end
+                withProfile(asyncProfile)
+            end)
+        end
+    end
+
+    local function prepareNearbyFirst(plugin, document, token, wantedTone)
+        local originalFile = document._burrow_epub_ornaments_source_file or document.file
+        if not isEpub(originalFile) then return end
+
+        local profile = document._burrow_epub_ornaments_profile
+            or OrnamentEpub.peekProfile(originalFile)
+        if profile then
+            document._burrow_epub_ornaments_profile = profile
+            if tonumber(profile.eligible_count) == 0 then return end
+        end
+
+        local fast = profile
+            and profile.all_eligible == true
+            and document._nightmode_images ~= false
+        local toneForFull = fast and "light" or wantedTone
+        local fullPalette = paletteName(Blitbuffer, toneForFull)
+        local cached, cacheErr, cachedCount = OrnamentEpub.cachedResult(
+            originalFile,
+            fullPalette
+        )
+        if cacheErr then
+            logger.warn("[Burrow ornaments] Full cache lookup failed", cacheErr)
+        elseif cached then
+            OrnamentEpub.setPreferredCache(originalFile, fullPalette, nil)
+            scheduleIdleReload(plugin, token, wantedTone)
+            startFullBackground(document, originalFile, wantedTone, profile)
+            return
+        elseif cachedCount == 0 then
+            return
+        end
+
+        -- If this document is already showing the requested tone (for example,
+        -- after the nearby cache reload), do not reload it again. Use the idle
+        -- time only for full-book completion.
+        if document._burrow_epub_ornaments_active == true
+            and (document._burrow_epub_ornaments_fast_adaptive == true
+                or document._burrow_epub_ornaments_tone == wantedTone)
+        then
+            startFullBackground(document, originalFile, wantedTone, profile)
+            return
+        end
+
+        local progress = currentProgress(document)
+        local hotTone = fast and "light" or wantedTone
+        local hotPalette = paletteName(Blitbuffer, hotTone)
+
+        OrnamentEpub.ensureHotCacheAsync(
+            originalFile,
+            hotPalette,
+            progress,
+            HOT_RADIUS,
+            function(shadow, err, count, meta)
+                if err then
+                    logger.warn("[Burrow ornaments] Nearby spine-priority cache failed", err)
+                    startFullBackground(document, originalFile, wantedTone, profile)
+                    return
+                end
+                if token ~= update_token then return end
+
+                local reader = plugin and plugin.ui or nil
+                local currentDocument = reader and reader.document or nil
+                if not currentDocument or reader.tearing_down then return end
+                if desiredTone(currentDocument, Screen) ~= wantedTone then return end
+
+                if shadow then
+                    -- The user may have moved several chapters while the hot cache
+                    -- was being built. Do not apply stale nearby work. Retarget the
+                    -- window around the new reading position instead.
+                    if not hotWindowStillRelevant(currentDocument, meta) then
+                        logger.dbg(
+                            "[Burrow ornaments] Reading position moved; retargeting nearby cache",
+                            meta and meta.center,
+                            meta and meta.total_spine
+                        )
+                        UIManager:scheduleIn(0.05, function()
+                            if token == update_token then
+                                prepareNearbyFirst(
+                                    plugin,
+                                    currentDocument,
+                                    token,
+                                    wantedTone
+                                )
+                            end
+                        end)
+                        return
+                    end
+
+                    OrnamentEpub.setPreferredCache(
+                        originalFile,
+                        hotPalette,
+                        shadow,
+                        count,
+                        meta
+                    )
+                    scheduleIdleReload(plugin, token, wantedTone)
+                end
+
+                -- Only after current/nearby sections have had first claim on CPU
+                -- do we begin scanning and converting the rest of the book.
+                startFullBackground(
+                    currentDocument,
+                    originalFile,
+                    wantedTone,
+                    profile
+                )
+            end
+        )
+    end
+
+    local function scheduleUpdate(plugin)
+        update_token = update_token + 1
+        if update_pending then return end
+        update_pending = true
+
+        UIManager:nextTick(function()
+            update_pending = false
+            local token = update_token
+
+            local reader = plugin and plugin.ui or nil
+            local document = reader and reader.document or nil
+            if not document or reader.tearing_down then return end
+            local originalFile = document._burrow_epub_ornaments_source_file or document.file
+            if not isEpub(originalFile) then return end
+            if not G_reader_settings:isTrue(ORNAMENT_SETTING)
+                or hasUserReaderPalette()
+            then
+                return
+            end
+
+            local logical_night = Screen.night_mode == true
+            if G_reader_settings:isTrue("night_mode") ~= logical_night then
+                logger.warn("[Burrow ornaments] Night Mode state is not settled; update skipped")
+                return
+            end
+
+            if not syncKindleNightMode(logger) then return end
+
+            local wanted = desiredTone(document, Screen)
+            if document._burrow_epub_ornaments_fast_adaptive == true then
+                if type(document.resetBufferCache) == "function" then
+                    pcall(document.resetBufferCache, document)
+                elseif document.buffer then
+                    pcall(document.buffer.free, document.buffer)
+                    document.buffer = nil
+                end
+                UIManager:setDirty(reader, "full")
+                logger.dbg("[Burrow ornaments] Repainted adaptive Night Mode without reload")
+                startFullBackground(
+                    document,
+                    originalFile,
+                    wanted,
+                    document._burrow_epub_ornaments_profile
+                )
+                return
+            end
+
+            if document._burrow_epub_ornaments_active == true
+                and wanted == document._burrow_epub_ornaments_tone
+            then
+                startFullBackground(
+                    document,
+                    originalFile,
+                    wanted,
+                    document._burrow_epub_ornaments_profile
+                )
+                return
+            end
+
+            prepareNearbyFirst(plugin, document, token, wanted)
+        end)
+    end
+
+    -- ReaderReady occurs after KOReader has restored the book position, which is
+    -- the earliest useful moment to decide which EPUB spine section is "current".
+    -- This gives first-open work the same current/nearby priority as Night Mode.
+    local originalReaderReady = plugin_class.onReaderReady
+    function plugin_class:onReaderReady(...)
+        local result
+        if originalReaderReady then result = originalReaderReady(self, ...) end
+        scheduleUpdate(self)
+        return result
+    end
+
+    local originalToggleNightMode = plugin_class.onToggleNightMode
+    function plugin_class:onToggleNightMode(...)
+        local result
+        if originalToggleNightMode then result = originalToggleNightMode(self, ...) end
+        scheduleUpdate(self)
+        return result
+    end
+
+    local originalSetNightMode = plugin_class.onSetNightMode
+    function plugin_class:onSetNightMode(...)
+        local result
+        if originalSetNightMode then result = originalSetNightMode(self, ...) end
+        scheduleUpdate(self)
+        return result
+    end
+
+    return true
+end
+
+return Module

--- a/plugins/burrow.koplugin/internal_patches/2-kindle-night-sync.lua
+++ b/plugins/burrow.koplugin/internal_patches/2-kindle-night-sync.lua
@@ -1,0 +1,82 @@
+local MODULE_KEY = "burrow.internal.2_kindle_night_sync"
+local existing_module = package.loaded[MODULE_KEY]
+if existing_module then return existing_module end
+
+local Module = {
+    key = MODULE_KEY,
+    phase = "early",
+    filename = "2-kindle-night-sync.lua",
+}
+package.loaded[MODULE_KEY] = Module
+
+function Module.sync()
+    local Device = require("device")
+
+    -- Kindle uses the framebuffer's hardware inversion flag for Night Mode.
+    -- KOReader keeps its own logical Screen.night_mode state separately. Keep
+    -- these synchronized without ever changing the user's saved Night Mode
+    -- preference or Device.orig_hw_nightmode. This is safe to call repeatedly,
+    -- including immediately before/after Burrow reloads an ornament shadow.
+    if not Device:isKindle()
+        or not Device:canHWInvert()
+        or not Device:canModifyFBInfo()
+    then
+        return true
+    end
+
+    local Screen = Device.screen
+    if type(Screen) ~= "table"
+        or type(Screen.getHWNightmode) ~= "function"
+        or type(Screen.setHWNightmode) ~= "function"
+    then
+        return false, "Kindle hardware Night Mode API is unavailable"
+    end
+
+    local ok_hw, hw_night = pcall(Screen.getHWNightmode, Screen)
+    if not ok_hw then
+        return false, "Could not read Kindle hardware Night Mode: " .. tostring(hw_night)
+    end
+
+    local logical_night = Screen.night_mode == true
+    hw_night = hw_night == true
+
+    if hw_night ~= logical_night then
+        local ok_set, set_error = pcall(
+            Screen.setHWNightmode,
+            Screen,
+            logical_night
+        )
+        if not ok_set then
+            return false, "Could not synchronize Kindle hardware Night Mode: "
+                .. tostring(set_error)
+        end
+
+        local ok_verify, verified_hw = pcall(Screen.getHWNightmode, Screen)
+        if not ok_verify or (verified_hw == true) ~= logical_night then
+            return false, "Kindle hardware Night Mode did not accept the requested state"
+        end
+
+        local UIManager = require("ui/uimanager")
+        UIManager:setDirty("all", "full")
+
+        local logger = require("logger")
+        logger.info(
+            "[Burrow] Synchronized Kindle hardware Night Mode with KOReader state",
+            logical_night
+        )
+    end
+
+    return true
+end
+
+function Module.apply()
+    if Module.applied then return true end
+
+    local ok, err = Module.sync()
+    if not ok then return false, err end
+
+    Module.applied = true
+    return true
+end
+
+return Module

--- a/plugins/burrow.koplugin/internal_patches/2-quick-settings-native-night.lua
+++ b/plugins/burrow.koplugin/internal_patches/2-quick-settings-native-night.lua
@@ -37,7 +37,9 @@ function Module.apply()
         return false, "Could not locate Quick Settings Night action"
     end
 
+    local Device = require("device")
     local Event = require("ui/event")
+    local TouchMenu = require("ui/widget/touchmenu")
     local UIManager = require("ui/uimanager")
 
     button_defs.night.callback = function(touch_menu)
@@ -45,6 +47,13 @@ function Module.apply()
         -- inversion, CRengine cache reset, highlight refresh, persistence and
         -- the repaint as one coordinated Night Mode transition.
         UIManager:broadcastEvent(Event:new("ToggleNightMode"))
+
+        -- Kindle e-ink refreshes are slow enough that immediately rebuilding the
+        -- entire custom Quick Settings panel can leave the visible panel behind
+        -- its live hitboxes for a moment. Do not rebuild it during that refresh.
+        -- The Night tile's active appearance will be correct the next time the
+        -- menu is opened. Other devices retain the existing next-tick refresh.
+        if Device:isKindle() then return end
 
         UIManager:nextTick(function()
             if touch_menu
@@ -54,6 +63,34 @@ function Module.apply()
                 touch_menu:updateItems(1)
             end
         end)
+    end
+
+    -- Burrow's custom panel normally checks its tile hitboxes before KOReader's
+    -- stock outside-menu close handler. On a slow Kindle Night Mode refresh, a
+    -- tap intended for the empty area below Quick Settings can therefore be
+    -- interpreted against stale tile geometry. Give outside taps absolute
+    -- priority and consume them after closing the menu.
+    if not TouchMenu._burrow_qs_outside_tap_priority then
+        TouchMenu._burrow_qs_outside_tap_priority = true
+        local original_onTapCloseAllMenus = TouchMenu.onTapCloseAllMenus
+
+        function TouchMenu:onTapCloseAllMenus(arg, ges_ev)
+            if self._rounded_qs_refs
+                and self.item_table
+                and self.item_table.panel
+                and self.dimen
+                and ges_ev
+                and ges_ev.pos
+                and ges_ev.pos:notIntersectWith(self.dimen)
+            then
+                self:closeMenu()
+                return true
+            end
+
+            if original_onTapCloseAllMenus then
+                return original_onTapCloseAllMenus(self, arg, ges_ev)
+            end
+        end
     end
 
     Module.applied = true

--- a/plugins/burrow.koplugin/internal_patches/2-soft-palette.lua
+++ b/plugins/burrow.koplugin/internal_patches/2-soft-palette.lua
@@ -19,7 +19,6 @@ function Module.apply()
     local CreDocument = require("document/credocument")
     local ImageWidget = require("ui/widget/imagewidget")
     local ReaderStyleTweak = require("apps/reader/modules/readerstyletweak")
-    local SoftPaletteEpub = require("burrow_soft_palette_epub")
     local logger = require("logger")
     local userpatch = require("userpatch")
 
@@ -27,7 +26,6 @@ function Module.apply()
     local BLACK_DEFAULT = 0x00
     local WHITE_SOFT = 0xF2
     local BLACK_SOFT = 0x20
-    local ORNAMENT_SETTING = "burrow_soft_palette_recolor_ornaments"
 
     local current_white = tonumber(Blitbuffer.COLOR_WHITE.a)
     local current_black = tonumber(Blitbuffer.COLOR_BLACK.a)
@@ -81,53 +79,6 @@ body {
     local function hasUserReaderPalette()
         return G_reader_settings:has("cre_background_color")
             or G_reader_settings:has("cre_background_image")
-    end
-
-    local function isEpub(path)
-        return type(path) == "string" and path:lower():match("%.epub$") ~= nil
-    end
-
-    -- Optional Kindle-like treatment for small monochrome EPUB artwork. Rather
-    -- than recoloring CRengine's final framebuffer, build a cached shadow EPUB
-    -- where only conservative ornament candidates have #000/#FFF mapped to the
-    -- same #202020/#F2F2F0 palette as the page. Large and colored images remain
-    -- byte-for-byte original. The reader-context marker prevents file-browser
-    -- cover and metadata probes from ever being redirected through this cache.
-    if not CreDocument._burrow_soft_palette_ornament_loader_v1 then
-        CreDocument._burrow_soft_palette_ornament_loader_v1 = true
-        local originalLoadDocument = CreDocument.loadDocument
-
-        function CreDocument:loadDocument(fullDocument)
-            if self._loaded
-                or fullDocument == false
-                or (self._burrow_soft_palette_reader_context ~= true
-                    and self._burrow_bionic_reader_context ~= true)
-                or not G_reader_settings:isTrue(ORNAMENT_SETTING)
-                or hasUserReaderPalette()
-                or not isEpub(self.file)
-            then
-                return originalLoadDocument(self, fullDocument)
-            end
-
-            local originalFile = self.file
-            local shadow, shadowErr = SoftPaletteEpub.ensureCache(originalFile)
-            if not shadow then
-                logger.warn("[Burrow palette] Falling back to original EPUB", shadowErr)
-                return originalLoadDocument(self, fullDocument)
-            end
-
-            self.file = shadow
-            local ok, result = pcall(originalLoadDocument, self, fullDocument)
-            self.file = originalFile
-            if not ok then error(result) end
-
-            if result then
-                self._burrow_soft_palette_ornaments_active = true
-                self._burrow_soft_palette_shadow_file = shadow
-                logger.info("[Burrow palette] Loaded ornament-adjusted EPUB")
-            end
-            return result
-        end
     end
 
     if not CreDocument._burrow_soft_palette_v5 then

--- a/plugins/burrow.koplugin/internal_patches/2-zzzz-soft-palette-settings.lua
+++ b/plugins/burrow.koplugin/internal_patches/2-zzzz-soft-palette-settings.lua
@@ -27,10 +27,10 @@ function Module.apply(plugin)
 
     local ORNAMENT_SETTING = "burrow_soft_palette_recolor_ornaments"
 
-    -- Mark the real reader CreDocument before CRengine loads it. The soft
-    -- palette EPUB shadow loader checks this marker so file-browser cover and
-    -- metadata probes are never redirected through a transformed copy. Keep
-    -- this wrapper composable with Bionic Reading and the other Burrow hooks.
+    -- Mark the real reader CreDocument before CRengine loads it. The
+    -- decorative EPUB shadow loader checks this marker so file-browser cover
+    -- and metadata probes are never redirected through a transformed copy.
+    -- Keep this wrapper composable with Bionic Reading and other Burrow hooks.
     if not plugin._burrow_soft_palette_reader_context_hook then
         plugin._burrow_soft_palette_reader_context_hook = true
         local originalDocSettingsLoad = plugin.onDocSettingsLoad
@@ -41,15 +41,16 @@ function Module.apply(plugin)
             end
             local doc = document or self.document or (self.ui and self.ui.document)
             if doc and doc.provider == "crengine" then
+                doc._burrow_epub_ornament_reader_context = true
+                -- Retain the old marker for same-process upgrade compatibility.
                 doc._burrow_soft_palette_reader_context = true
             end
             return result
         end
     end
 
-    -- This is an experimental test overlay. Turn the new ornament treatment on
-    -- for first-time testers so reopening an EPUB immediately exercises it.
-    -- The setting remains independently switchable in Burrow Settings.
+    -- Preserve the existing default and every saved user choice. Decorative
+    -- EPUB handling now works independently of the optional soft palette.
     if G_reader_settings:readSetting(ORNAMENT_SETTING) == nil then
         G_reader_settings:saveSetting(ORNAMENT_SETTING, true)
     end
@@ -346,11 +347,10 @@ function Module.apply(plugin)
                     },
                     {
                         text = _("Recolor decorative book elements"),
-                        help_text = _("For EPUB books, recolor only small monochrome images and simple SVG ornaments to match Burrow's soft page colors. Covers, large images, and colored artwork are left unchanged. Reopen the book after changing this setting."),
+                        help_text = _("Normalize qualifying small monochrome EPUB decorations to true grayscale so KOReader's native Night Mode inversion can follow the page. Covers, photographs, colored artwork, and other images keep KOReader's normal image behavior. Reopen the book after changing this setting."),
                         checked_func = function()
                             return G_reader_settings:isTrue(ORNAMENT_SETTING)
                         end,
-                        enabled_func = enabled,
                         callback = function()
                             G_reader_settings:saveSetting(
                                 ORNAMENT_SETTING,

--- a/plugins/burrow.koplugin/main.lua
+++ b/plugins/burrow.koplugin/main.lua
@@ -118,6 +118,24 @@ local Burrow = WidgetContainer:extend {
     name = "burrow",
 }
 
+-- Decorative EPUB palettes need to observe Night Mode only after KOReader's
+-- native DeviceListener has completed the transition. Burrow plugin instances
+-- are registered after DeviceListener, so attach the observer to Burrow itself
+-- instead of wrapping KOReader's Night Mode owner.
+local OrnamentModule = package.loaded["burrow.internal.2_epub_ornaments"]
+if type(OrnamentModule) == "table"
+    and type(OrnamentModule.attachPluginClass) == "function"
+then
+    local ok, err = pcall(OrnamentModule.attachPluginClass, Burrow)
+    if not ok then
+        logger.warn(
+            burrow_debug.logprefix,
+            "Decorative EPUB Night Mode observer could not attach",
+            err
+        )
+    end
+end
+
 -- Bionic Reading is loaded only with Burrow Quick Settings. When present, let
 -- it mark the actual ReaderUI document during DocSettingsLoad so its CRengine
 -- shadow-file hook never touches File Manager metadata/cover probes.


### PR DESCRIPTION
Promote the tested 0.4.4-beta.6 runtime to stable without replacing the current stable tree.

This promotion is based directly on current `main` (0.4.3). It overlays only the nine beta.6 files that actually differ from stable and changes the version metadata to 0.4.4. All other current stable files remain byte-for-byte unchanged.

Included from the tested beta.6 line:
- selective explicit EPUB ornament Night Mode handling
- Kindle hardware Night Mode synchronization
- cooperative/spine-priority ornament cache preparation for faster book entry and mode switching
- Kindle Quick Settings Night Mode dismissal and refresh fix

Explicitly excluded:
- the abandoned color-safe ornament experiment
- any unrelated cleanup or feature removal

The 0.4.4 beta.6 behavior was device-tested on Android and Kindle.