### PR TITLE
Burrow 0.4.6-beta.1 stable page numbers

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - main
       - agent/self-updater
-      - agent/0.4.6-beta.1-stable-page-numbers
     paths:
       - 'README.md'
       - 'INSTALL.txt'

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
       - agent/self-updater
+      - agent/0.4.6-beta.1-stable-page-numbers
     paths:
       - 'README.md'
       - 'INSTALL.txt'

--- a/plugins/burrow.koplugin/burrow_settings.lua
+++ b/plugins/burrow.koplugin/burrow_settings.lua
@@ -187,6 +187,16 @@ function BurrowSettings:getModuleManifest()
         feature = "epub_ornaments",
     })
 
+    -- Prefer layout-independent page labels for reflowable books. Publisher
+    -- page maps win when the document provides them; otherwise Burrow builds
+    -- KOReader's native synthetic map (1500 chars/page unless the user already
+    -- selected a different value). The footer and Reading Location already
+    -- consume these labels when page maps are active.
+    add("stable_page_numbers", "2-stable-page-numbers.lua", "early", {
+        filename = "2-stable-page-numbers.lua",
+        feature = "stable_page_numbers",
+    })
+
     if self:isFeatureEnabled("quick_settings") then
         add("quick_settings", "2-quick-settings.lua", "early", {
             filename = "2-quick-settings.lua",

--- a/plugins/burrow.koplugin/burrow_version.lua
+++ b/plugins/burrow.koplugin/burrow_version.lua
@@ -1,6 +1,6 @@
 return {
-    VERSION = "0.4.5",
-    DISPLAY_VERSION = "0.4.5",
+    VERSION = "0.4.6-beta.1",
+    DISPLAY_VERSION = "0.4.6-beta.1",
     STORE_ENGINE_VERSION = "1.2.1",
 
     -- Burrow is tested against KOReader 2026.07.2. Older releases are blocked,

--- a/plugins/burrow.koplugin/internal_patches/2-stable-page-numbers.lua
+++ b/plugins/burrow.koplugin/internal_patches/2-stable-page-numbers.lua
@@ -1,0 +1,91 @@
+local MODULE_KEY = "burrow.internal.2_stable_page_numbers"
+local existing_module = package.loaded[MODULE_KEY]
+if existing_module then return existing_module end
+
+local Module = {
+    key = MODULE_KEY,
+    phase = "early",
+    filename = "2-stable-page-numbers.lua",
+}
+package.loaded[MODULE_KEY] = Module
+
+function Module.apply()
+    if Module.applied then return true end
+
+    local ReaderPageMap = require("apps/reader/modules/readerpagemap")
+    if ReaderPageMap._burrow_stable_page_numbers_v1 then
+        Module.applied = true
+        return true
+    end
+    ReaderPageMap._burrow_stable_page_numbers_v1 = true
+
+    local DEFAULT_CHARS_PER_PAGE = 1500
+    local original_onReadSettings = ReaderPageMap.onReadSettings
+    local original_postInit = ReaderPageMap._postInit
+
+    -- Stable labels should be the normal Burrow presentation for reflowable
+    -- documents. Do not touch fixed-layout readers (PDF/CBZ/DjVu/etc.).
+    function ReaderPageMap:onReadSettings(config)
+        local result = original_onReadSettings(self, config)
+        if self.ui and self.ui.rolling then
+            self.use_page_labels = true
+            config:saveSetting("pagemap_use_page_labels", true)
+        end
+        return result
+    end
+
+    function ReaderPageMap:_postInit(...)
+        local result = original_postInit(self, ...)
+
+        if not (self.ui and self.ui.rolling and self.ui.document and self.ui.doc_settings) then
+            return result
+        end
+
+        local document = self.ui.document
+
+        -- If KOReader already has a page map, leave its source alone. This keeps
+        -- publisher-supplied page maps intact and also respects an existing
+        -- user-selected synthetic map.
+        if not self.has_pagemap then
+            local chars = tonumber(
+                self.ui.doc_settings:readSetting("pagemap_chars_per_synthetic_page")
+                or G_reader_settings:readSetting("pagemap_chars_per_synthetic_page")
+                or self.chars_per_synthetic_page
+                or self.chars_per_synthetic_page_default
+                or DEFAULT_CHARS_PER_PAGE
+            ) or DEFAULT_CHARS_PER_PAGE
+
+            if chars < 500 then chars = 500 end
+            if chars > 3000 then chars = 3000 end
+
+            local ok = pcall(document.buildSyntheticPageMap, document, chars)
+            if ok and document:hasPageMap() then
+                self.chars_per_synthetic_page = chars
+                self.has_pagemap = true
+                self.page_labels_cache = nil
+                self:resetLayout()
+                self.view:registerViewModule("pagemap", self)
+                self.ui.doc_settings:saveSetting("pagemap_chars_per_synthetic_page", chars)
+                self.ui.doc_settings:saveSetting(
+                    "pagemap_doc_pages",
+                    select(3, self:getCurrentPageLabel())
+                )
+            end
+        end
+
+        if self.has_pagemap then
+            -- The footer, Reading Location, bookmarks and other KOReader
+            -- consumers already switch to page-map labels through this flag.
+            self.use_page_labels = true
+            self.page_labels_cache = nil
+            self.ui.doc_settings:saveSetting("pagemap_use_page_labels", true)
+        end
+
+        return result
+    end
+
+    Module.applied = true
+    return true
+end
+
+return Module


### PR DESCRIPTION
Superseded by the published Burrow 0.4.6 beta line.

The stable page-number work from this PR was carried forward through beta.2, beta.3, beta.4, and is present in the exact Android-tested 0.4.6-beta.5 tree now published on the Burrow beta channel (`agent/self-updater`).

This PR is being closed without merge so the old staging ancestry is not introduced into `main`. The feature itself is preserved and remains part of the current beta tree.