### PR TITLE
Burrow 0.4.6-beta.2 responsive hero alignment

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - main
       - agent/self-updater
-      - agent/0.4.6-beta.1-stable-page-numbers
     paths:
       - 'README.md'
       - 'INSTALL.txt'

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
       - agent/self-updater
+      - agent/0.4.6-beta.2-hero-grid-alignment
     paths:
       - 'README.md'
       - 'INSTALL.txt'

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
       - agent/self-updater
+      - agent/0.4.6-beta.1-stable-page-numbers
     paths:
       - 'README.md'
       - 'INSTALL.txt'

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - main
       - agent/self-updater
-      - agent/0.4.6-beta.2-hero-grid-alignment
     paths:
       - 'README.md'
       - 'INSTALL.txt'

--- a/plugins/burrow.koplugin/burrow_settings.lua
+++ b/plugins/burrow.koplugin/burrow_settings.lua
@@ -187,6 +187,16 @@ function BurrowSettings:getModuleManifest()
         feature = "epub_ornaments",
     })
 
+    -- Prefer layout-independent page labels for reflowable books. Publisher
+    -- page maps win when the document provides them; otherwise Burrow builds
+    -- KOReader's native synthetic map (1500 chars/page unless the user already
+    -- selected a different value). The footer and Reading Location already
+    -- consume these labels when page maps are active.
+    add("stable_page_numbers", "2-stable-page-numbers.lua", "early", {
+        filename = "2-stable-page-numbers.lua",
+        feature = "stable_page_numbers",
+    })
+
     if self:isFeatureEnabled("quick_settings") then
         add("quick_settings", "2-quick-settings.lua", "early", {
             filename = "2-quick-settings.lua",

--- a/plugins/burrow.koplugin/burrow_settings.lua
+++ b/plugins/burrow.koplugin/burrow_settings.lua
@@ -147,6 +147,16 @@ function BurrowSettings:getModuleManifest()
         visual("cover_layout", "2-z-burrow-cover-layout.lua", {
             "library_core", "rounded_covers", "folder_consistency",
         })
+
+        -- Keep the hero border aligned to the actual outer cover edges after
+        -- final cover sizing and gap reduction have been applied. This is an
+        -- isolated non-critical layer so a geometry mismatch cannot quarantine
+        -- Burrow's core library styling.
+        add("hero_grid_alignment", "2-hero-card-grid-alignment.lua", "instance", {
+            filename = "2-hero-card-grid-alignment.lua",
+            feature = "hero_grid_alignment",
+            depends = { "library_core", "hero_card", "cover_layout" },
+        })
     else
         -- Series grouping and Return to Library remain available without Burrow's
         -- visual styling, but when styling is enabled they must load after the

--- a/plugins/burrow.koplugin/burrow_version.lua
+++ b/plugins/burrow.koplugin/burrow_version.lua
@@ -1,6 +1,6 @@
 return {
-    VERSION = "0.4.6-beta.1",
-    DISPLAY_VERSION = "0.4.6-beta.1",
+    VERSION = "0.4.6-beta.2",
+    DISPLAY_VERSION = "0.4.6-beta.2",
     STORE_ENGINE_VERSION = "1.2.1",
 
     -- Burrow is tested against KOReader 2026.07.2. Older releases are blocked,

--- a/plugins/burrow.koplugin/burrow_version.lua
+++ b/plugins/burrow.koplugin/burrow_version.lua
@@ -1,6 +1,6 @@
 return {
-    VERSION = "0.4.5",
-    DISPLAY_VERSION = "0.4.5",
+    VERSION = "0.4.6-beta.1",
+    DISPLAY_VERSION = "0.4.6-beta.1",
     STORE_ENGINE_VERSION = "1.2.1",
 
     -- Burrow is tested against KOReader 2026.07.2. Older releases are blocked,

--- a/plugins/burrow.koplugin/internal_patches/2-hero-card-grid-alignment.lua
+++ b/plugins/burrow.koplugin/internal_patches/2-hero-card-grid-alignment.lua
@@ -1,0 +1,203 @@
+local MODULE_KEY = "burrow.internal.2_hero_card_grid_alignment"
+local existing_module = package.loaded[MODULE_KEY]
+if existing_module then return existing_module end
+
+local Module = {
+    key = MODULE_KEY,
+    phase = "instance",
+    filename = "2-hero-card-grid-alignment.lua",
+}
+package.loaded[MODULE_KEY] = Module
+
+local function patchHeroGridAlignment(plugin)
+    local BookInfoManager = require("bookinfomanager")
+    local CoverMenu = require("covermenu")
+    local Menu = require("ui/widget/menu")
+    local Screen = require("device").screen
+    local UIManager = require("ui/uimanager")
+    local logger = require("logger")
+
+    if CoverMenu._burrow_hero_grid_alignment_v1 then
+        return true
+    end
+
+    local function round(value)
+        if value >= 0 then
+            return math.floor(value + 0.5)
+        end
+        return math.ceil(value - 0.5)
+    end
+
+    local function findUpvalueIndex(func, wanted_name)
+        if type(func) ~= "function" then return nil end
+        local index = 1
+        while true do
+            local name = debug.getupvalue(func, index)
+            if not name then return nil end
+            if name == wanted_name then return index end
+            index = index + 1
+        end
+    end
+
+    -- The hero module deliberately installs its composite TitleBar into this
+    -- upvalue. Retrieve that existing class rather than replacing the titlebar
+    -- or rebuilding any of its UI ourselves.
+    local titlebar_index = findUpvalueIndex(CoverMenu.setupLayout, "TitleBar")
+    local HeroTitleBar = titlebar_index
+        and select(2, debug.getupvalue(CoverMenu.setupLayout, titlebar_index))
+
+    if not HeroTitleBar or type(HeroTitleBar.refreshHero) ~= "function" then
+        logger.warn("Burrow hero alignment: hero titlebar unavailable; leaving existing geometry unchanged")
+        return true
+    end
+
+    -- buildHeroArea owns the existing HERO_SIDE_MARGIN upvalue. Updating that
+    -- single value lets the existing hero rebuild itself normally, preserving
+    -- all current cover, text, progress, tap, hold, and refresh behavior.
+    local build_index = findUpvalueIndex(HeroTitleBar.refreshHero, "buildHeroArea")
+    local buildHeroArea = build_index
+        and select(2, debug.getupvalue(HeroTitleBar.refreshHero, build_index))
+    local margin_index = findUpvalueIndex(buildHeroArea, "HERO_SIDE_MARGIN")
+    local default_side_margin
+    if margin_index then
+        local _, value = debug.getupvalue(buildHeroArea, margin_index)
+        default_side_margin = value
+    end
+
+    if not buildHeroArea or not margin_index or type(default_side_margin) ~= "number" then
+        logger.warn("Burrow hero alignment: hero margin upvalue unavailable; leaving existing geometry unchanged")
+        return true
+    end
+
+    local function widgetWidth(widget)
+        if type(widget) ~= "table" then return nil end
+        if type(widget.getSize) == "function" then
+            local ok, size = pcall(widget.getSize, widget)
+            if ok and size and tonumber(size.w) and tonumber(size.w) > 0 then
+                return tonumber(size.w)
+            end
+        end
+        if widget.dimen and tonumber(widget.dimen.w) and tonumber(widget.dimen.w) > 0 then
+            return tonumber(widget.dimen.w)
+        end
+        if tonumber(widget.width) and tonumber(widget.width) > 0 then
+            return tonumber(widget.width)
+        end
+    end
+
+    local function findRenderedCoverWidth(widget, seen)
+        if type(widget) ~= "table" then return nil end
+        seen = seen or {}
+        if seen[widget] then return nil end
+        seen[widget] = true
+
+        -- The final Burrow cover-layout pass stores the exact frame it resized
+        -- on every normal book, physical folder, and virtual series tile.
+        local explicit = widget._burrow_primary_cover_frame
+            or widget._burrow_cover_size_frame
+        local width = widgetWidth(explicit)
+        if width then return width end
+
+        for i = 1, #widget do
+            width = findRenderedCoverWidth(widget[i], seen)
+            if width then return width end
+        end
+        return nil
+    end
+
+    local function normalizeGap(value)
+        value = tonumber(value) or 0
+        value = math.floor(value + 0.5)
+        if value < 0 then value = 0 end
+        if value > 30 then value = 30 end
+        return value
+    end
+
+    local function alignedSideMargin(menu)
+        if type(menu) ~= "table" then return default_side_margin end
+
+        local columns = tonumber(menu.nb_cols)
+        local item_width = tonumber(menu.item_width)
+        local item_margin = tonumber(menu.item_margin)
+        if not columns or columns < 2 or not item_width or not item_margin then
+            -- One-column and non-grid layouts keep the existing hero geometry.
+            -- The current hero is a horizontal cover-and-text card and would be
+            -- unusably narrow if forced to the width of a single small cover.
+            return default_side_margin
+        end
+
+        local cover_width = findRenderedCoverWidth(menu.item_group)
+        if not cover_width then
+            return default_side_margin
+        end
+
+        -- Cover gap reduction shifts whole tiles inward toward the center.
+        -- Mirror the exact shift used by the final cover-layout paint wrapper.
+        local gap_step = Screen:scaleBySize(normalizeGap(
+            BookInfoManager:getSetting("burrow_cover_gap_reduction")
+        ))
+        local center_column = (columns + 1) / 2
+        local first_shift = round((center_column - 1) * gap_step)
+        local last_shift = round((center_column - columns) * gap_step)
+
+        -- Centers of the first and last grid tiles are separated by one item
+        -- width plus one item margin per column step. Add the exact rendered
+        -- cover width, then apply the inward shifts from gap reduction.
+        local cover_span = (columns - 1) * (item_width + item_margin)
+            + last_shift - first_shift + cover_width
+
+        local screen_width = Screen:getWidth()
+        cover_span = math.max(1, math.min(screen_width, round(cover_span)))
+
+        -- Preserve the current horizontal hero on very narrow grids rather than
+        -- allowing its cover and text to overlap. Standard multi-column grids
+        -- align exactly; narrow layouts retain the existing safe card width.
+        local current_card_width = screen_width - 2 * default_side_margin
+        local minimum_safe_width = math.min(current_card_width, Screen:scaleBySize(360))
+        if cover_span < minimum_safe_width then
+            return default_side_margin
+        end
+
+        return math.max(0, round((screen_width - cover_span) / 2))
+    end
+
+    local original_update_items = CoverMenu.updateItems
+    local menu_was_using_covermenu_update = Menu.updateItems == original_update_items
+
+    function CoverMenu:updateItems(...)
+        -- Let every existing Burrow layer build the page first. In particular,
+        -- this gives the final cover-layout wrapper a chance to expose the exact
+        -- rendered cover frame width before we measure anything.
+        local result = original_update_items(self, ...)
+
+        local target_margin = alignedSideMargin(self)
+        local _, current_margin = debug.getupvalue(buildHeroArea, margin_index)
+        if current_margin ~= target_margin then
+            debug.setupvalue(buildHeroArea, margin_index, target_margin)
+            if self.title_bar and type(self.title_bar.refreshHero) == "function" then
+                local ok, changed = pcall(self.title_bar.refreshHero, self.title_bar, true)
+                if not ok then
+                    -- Restore the known-safe original width immediately. This
+                    -- layer is cosmetic and must never strand the library UI.
+                    debug.setupvalue(buildHeroArea, margin_index, default_side_margin)
+                    logger.warn("Burrow hero alignment: refresh failed; restored default margin", tostring(changed))
+                elseif changed and self.show_parent then
+                    UIManager:setDirty(self.show_parent, "ui")
+                end
+            end
+        end
+
+        return result
+    end
+
+    if menu_was_using_covermenu_update then
+        Menu.updateItems = CoverMenu.updateItems
+    end
+
+    CoverMenu._burrow_hero_grid_alignment_v1 = true
+    logger.info("Burrow hero grid alignment loaded")
+    return true
+end
+
+Module.apply = patchHeroGridAlignment
+return Module

--- a/plugins/burrow.koplugin/internal_patches/2-stable-page-numbers.lua
+++ b/plugins/burrow.koplugin/internal_patches/2-stable-page-numbers.lua
@@ -1,0 +1,91 @@
+local MODULE_KEY = "burrow.internal.2_stable_page_numbers"
+local existing_module = package.loaded[MODULE_KEY]
+if existing_module then return existing_module end
+
+local Module = {
+    key = MODULE_KEY,
+    phase = "early",
+    filename = "2-stable-page-numbers.lua",
+}
+package.loaded[MODULE_KEY] = Module
+
+function Module.apply()
+    if Module.applied then return true end
+
+    local ReaderPageMap = require("apps/reader/modules/readerpagemap")
+    if ReaderPageMap._burrow_stable_page_numbers_v1 then
+        Module.applied = true
+        return true
+    end
+    ReaderPageMap._burrow_stable_page_numbers_v1 = true
+
+    local DEFAULT_CHARS_PER_PAGE = 1500
+    local original_onReadSettings = ReaderPageMap.onReadSettings
+    local original_postInit = ReaderPageMap._postInit
+
+    -- Stable labels should be the normal Burrow presentation for reflowable
+    -- documents. Do not touch fixed-layout readers (PDF/CBZ/DjVu/etc.).
+    function ReaderPageMap:onReadSettings(config)
+        local result = original_onReadSettings(self, config)
+        if self.ui and self.ui.rolling then
+            self.use_page_labels = true
+            config:saveSetting("pagemap_use_page_labels", true)
+        end
+        return result
+    end
+
+    function ReaderPageMap:_postInit(...)
+        local result = original_postInit(self, ...)
+
+        if not (self.ui and self.ui.rolling and self.ui.document and self.ui.doc_settings) then
+            return result
+        end
+
+        local document = self.ui.document
+
+        -- If KOReader already has a page map, leave its source alone. This keeps
+        -- publisher-supplied page maps intact and also respects an existing
+        -- user-selected synthetic map.
+        if not self.has_pagemap then
+            local chars = tonumber(
+                self.ui.doc_settings:readSetting("pagemap_chars_per_synthetic_page")
+                or G_reader_settings:readSetting("pagemap_chars_per_synthetic_page")
+                or self.chars_per_synthetic_page
+                or self.chars_per_synthetic_page_default
+                or DEFAULT_CHARS_PER_PAGE
+            ) or DEFAULT_CHARS_PER_PAGE
+
+            if chars < 500 then chars = 500 end
+            if chars > 3000 then chars = 3000 end
+
+            local ok = pcall(document.buildSyntheticPageMap, document, chars)
+            if ok and document:hasPageMap() then
+                self.chars_per_synthetic_page = chars
+                self.has_pagemap = true
+                self.page_labels_cache = nil
+                self:resetLayout()
+                self.view:registerViewModule("pagemap", self)
+                self.ui.doc_settings:saveSetting("pagemap_chars_per_synthetic_page", chars)
+                self.ui.doc_settings:saveSetting(
+                    "pagemap_doc_pages",
+                    select(3, self:getCurrentPageLabel())
+                )
+            end
+        end
+
+        if self.has_pagemap then
+            -- The footer, Reading Location, bookmarks and other KOReader
+            -- consumers already switch to page-map labels through this flag.
+            self.use_page_labels = true
+            self.page_labels_cache = nil
+            self.ui.doc_settings:saveSetting("pagemap_use_page_labels", true)
+        end
+
+        return result
+    end
+
+    Module.applied = true
+    return true
+end
+
+return Module


### PR DESCRIPTION
Superseded by the published Burrow 0.4.6 beta line.

The responsive hero-card alignment from this PR was carried forward into the later hero sizing/contrast/spacing work and is present in the exact Android-tested 0.4.6-beta.5 tree now published on the Burrow beta channel (`agent/self-updater`).

This PR is being closed without merge so the old staging ancestry is not introduced into `main`. The feature itself is preserved and remains part of the current beta tree.