### PR TITLE
Fix OPDS sync persistence across restarts

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - main
       - agent/self-updater
-      - agent/0.4.7-beta.1-store-sync-persistence
     paths:
       - 'README.md'
       - 'INSTALL.txt'
@@ -76,7 +75,6 @@ jobs:
           if-no-files-found: error
 
       - name: Create or update GitHub Release
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/agent/self-updater'
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ steps.release.outputs.tag }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
       - agent/self-updater
+      - agent/0.4.7-beta.1-store-sync-persistence
     paths:
       - 'README.md'
       - 'INSTALL.txt'
@@ -75,6 +76,7 @@ jobs:
           if-no-files-found: error
 
       - name: Create or update GitHub Release
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/agent/self-updater'
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ steps.release.outputs.tag }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Burrow will be documented here.
 
 ## [Unreleased]
 
+## [0.4.7-beta.2] - 2026-08-30
+
+### Fixed
+
+- Made OPDS sync resolve a canonical immediate book shelf when the configured catalog URL is a navigation-only root, instead of requiring nested catalog URLs to end in `.opds`.
+- Avoided recursively crawling author, series, category, genre, and tag indexes while discovering the book shelf, preventing duplicate-library traversal.
+- Hardened mixed navigation/book feeds so sync uses the first real acquisition entry rather than assuming the first feed entry is always a book.
+- Added a distinct message when a selected catalog contains no discoverable downloadable book shelf instead of incorrectly reporting `Up to date!`.
+
 ## [0.4.7-beta.1] - 2026-08-30
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to Burrow will be documented here.
 
 ## [Unreleased]
 
+## [0.4.7-beta.1] - 2026-08-30
+
+### Fixed
+
+- Made Burrow Store sync folder, file-type, maximum-download, catalog, and credential changes persist immediately across KOReader restarts.
+- Repaired the Store settings save path so the root settings table is no longer written inside itself, and migrated usable legacy nested Store settings into the current schema.
+- Forwarded KOReader settings flush events from the main Burrow plugin to the embedded Store as a fallback persistence path.
+- Persisted OPDS pending-sync work and catalog checkpoints together before downloads begin so interrupted or restarted syncs can resume safely.
+- Persisted the pending-sync list again after each download pass so completed and failed work survives correctly.
+- Prevented `Sync all catalogs` from reporting `Up to date!` when no catalogs are actually enabled for sync.
+- Prevented duplicate pending-sync entries after a restart and preserved dormant pending items for catalogs that are not part of the current sync run.
+- Preserved each catalog's `last_download` sync cursor when editing its settings.
+- Restored the one-entry subcatalog fallback used by KOReader's OPDS sync path and made file-type filters case-insensitive.
+
 ## [0.4.6] - 2026-08-28
 
 ### Added

--- a/plugins/burrow.koplugin/burrow_library.lua
+++ b/plugins/burrow.koplugin/burrow_library.lua
@@ -328,6 +328,15 @@ function Methods:onShowBurrowStore()
     end
 end
 
+function Methods:onFlushSettings()
+    if self.store and type(self.store.onFlushSettings) == "function" then
+        local ok, err = pcall(self.store.onFlushSettings, self.store)
+        if not ok then
+            logger.warn(burrow_debug.logprefix, "Burrow Store settings flush failed", err)
+        end
+    end
+end
+
 function Methods:onSyncBurrowStore()
     if self.store then
         self.store:_startSyncFromDispatcher(false)

--- a/plugins/burrow.koplugin/burrow_store/config/settings.lua
+++ b/plugins/burrow.koplugin/burrow_store/config/settings.lua
@@ -17,8 +17,28 @@ function Settings:new(settings_file)
 
 	o.settings_file = settings_file or BurrowMigration.storeSettingsPath()
 	o.storage = LuaSettings:open(o.settings_file)
+	o.is_first_run = next(o.storage.data) == nil
+
+	-- Burrow Store keeps its active preferences in the root LuaSettings table.
+	-- Older OPDS data may still contain a nested "settings" table, while some
+	-- 0.4.6 paths accidentally tried to save the root table inside itself.
+	-- Migrate any usable nested values into the flat Burrow Store schema once,
+	-- then remove the nested key so future flushes can never serialize a loop.
+	local nested_settings = o.storage:readSetting("settings")
+	o.did_migrate = false
+	if type(nested_settings) == "table" and nested_settings ~= o.storage.data then
+		for key, value in pairs(nested_settings) do
+			if o.storage.data[key] == nil then
+				o.storage.data[key] = value
+			end
+		end
+		o.storage:delSetting("settings")
+		o.storage:saveSetting("burrow_store_flat_settings_v1", true)
+		o.storage:flush()
+		o.did_migrate = true
+	end
+
 	o.data = o.storage.data
-	o.is_first_run = next(o.data) == nil
 
 	return o
 end
@@ -55,7 +75,9 @@ end
 
 --- Save settings to storage
 function Settings:save()
-	self.storage:saveSetting("settings", self.data)
+	-- self.data is the storage root, so saving it below a "settings" key would
+	-- create a self-reference. Flushing the root is the correct persistence path.
+	self.storage:flush()
 end
 
 --- Flush settings to disk

--- a/plugins/burrow.koplugin/burrow_store/config/settings_menu.lua
+++ b/plugins/burrow.koplugin/burrow_store/config/settings_menu.lua
@@ -87,9 +87,7 @@ function SettingsMenu.create(plugin)
 								return mode == "list" or mode == nil
 							end,
 							callback = function()
-								plugin.settings.display_mode = "list"
-								plugin.opds_settings:saveSetting("settings", plugin.settings)
-								plugin.opds_settings:flush()
+								plugin:saveSetting("display_mode", "list")
 								UIManager:show(InfoMessage:new {
 									text = _("Display mode set to List View.\n\nChanges will apply when you next browse a catalog."),
 									timeout = 2,
@@ -102,9 +100,7 @@ function SettingsMenu.create(plugin)
 								return plugin.settings.display_mode == "grid"
 							end,
 							callback = function()
-								plugin.settings.display_mode = "grid"
-								plugin.opds_settings:saveSetting("settings", plugin.settings)
-								plugin.opds_settings:flush()
+								plugin:saveSetting("display_mode", "grid")
 								UIManager:show(InfoMessage:new {
 									text = _("Display mode set to Grid View.\n\nChanges will apply when you next browse a catalog."),
 									timeout = 2,
@@ -272,9 +268,7 @@ function SettingsMenu.create(plugin)
 								return plugin.settings.debug_mode == true
 							end,
 							callback = function()
-								plugin.settings.debug_mode = not plugin.settings.debug_mode
-								plugin.opds_settings:saveSetting("settings", plugin.settings)
-								plugin.opds_settings:flush()
+								plugin:saveSetting("debug_mode", not plugin.settings.debug_mode)
 								UIManager:show(InfoMessage:new {
 									text = plugin.settings.debug_mode and
 										_("Debug mode enabled.\n\nDetailed logging is now active.") or

--- a/plugins/burrow.koplugin/burrow_store/core/catalog_manager.lua
+++ b/plugins/burrow.koplugin/burrow_store/core/catalog_manager.lua
@@ -31,13 +31,15 @@ end
 -- @param no_refresh boolean Don't refresh item table if true
 -- @return number, number New index, item number for refresh
 function CatalogManager.editCatalogFromInput(servers, item_table, fields, item, no_refresh)
+	local existing_server = item and servers[item.idx - 1] or nil
 	local new_server = {
-		title     = fields[1],
-		url       = fields[2]:match("^%a+://") and fields[2] or "http://" .. fields[2],
-		username  = fields[3] ~= "" and fields[3] or nil,
-		password  = fields[4] ~= "" and fields[4] or nil,
-		raw_names = fields[5],
-		sync      = fields[6],
+		title         = fields[1],
+		url           = fields[2]:match("^%a+://") and fields[2] or "http://" .. fields[2],
+		username      = fields[3] ~= "" and fields[3] or nil,
+		password      = fields[4] ~= "" and fields[4] or nil,
+		raw_names     = fields[5],
+		sync          = fields[6],
+		last_download = existing_server and existing_server.last_download or nil,
 	}
 
 	local new_item = CatalogUtils.buildRootEntry(new_server)

--- a/plugins/burrow.koplugin/burrow_store/core/download_manager.lua
+++ b/plugins/burrow.koplugin/burrow_store/core/download_manager.lua
@@ -465,7 +465,9 @@ function DownloadManager.downloadPendingSyncs(browser, dl_list)
 			})
 		end
 
-		StateManager.getInstance():markDirty()
+		local state = StateManager.getInstance()
+		state:markDirty()
+		state:saveNow()
 		return duplicate_list
 	end
 

--- a/plugins/burrow.koplugin/burrow_store/core/download_manager.lua
+++ b/plugins/burrow.koplugin/burrow_store/core/download_manager.lua
@@ -426,24 +426,28 @@ function DownloadManager.downloadPendingSyncs(browser, dl_list)
 		local dl_size = #dl_list
 		for i = dl_size, 1, -1 do
 			local item = dl_list[i]
-			if downloaded and downloaded[item.file] then
-				invalidateBookInfo(item.file)
-				dl_count = dl_count + 1
-				table.remove(dl_list, i)
-			else -- if subprocess has been interrupted, check for the downloaded file
-				local attr = lfs.attributes(item.file)
-				if attr then
-					if attr.size > 0 then
-						-- Forced sync may have replaced an already cached pathname.
-						-- Invalidate before the library can reuse the old metadata.
-						invalidateBookInfo(item.file)
-						table.remove(dl_list, i)
-						-- Only count files touched within the freshness window
-						if attr.modification > os.time() - Constants.SYNC.DOWNLOAD_FRESHNESS_SECONDS then
-							dl_count = dl_count + 1
+			-- A pending item from a catalog that is not part of this sync run must
+			-- remain untouched so it can resume if that catalog is enabled later.
+			if browser.sync_server_list[item.catalog] then
+				if downloaded and downloaded[item.file] then
+					invalidateBookInfo(item.file)
+					dl_count = dl_count + 1
+					table.remove(dl_list, i)
+				else -- if subprocess has been interrupted, check for the downloaded file
+					local attr = lfs.attributes(item.file)
+					if attr then
+						if attr.size > 0 then
+							-- Forced sync may have replaced an already cached pathname.
+							-- Invalidate before the library can reuse the old metadata.
+							invalidateBookInfo(item.file)
+							table.remove(dl_list, i)
+							-- Only count files touched within the freshness window
+							if attr.modification > os.time() - Constants.SYNC.DOWNLOAD_FRESHNESS_SECONDS then
+								dl_count = dl_count + 1
+							end
+						else -- incomplete download
+							os.remove(item.file)
 						end
-					else -- incomplete download
-						os.remove(item.file)
 					end
 				end
 			end

--- a/plugins/burrow.koplugin/burrow_store/core/state_manager.lua
+++ b/plugins/burrow.koplugin/burrow_store/core/state_manager.lua
@@ -58,6 +58,15 @@ function StateManager:markClean()
 	self:_notifyListeners("clean")
 end
 
+--- Persist all Store state immediately when the embedded Store owns storage.
+-- @return boolean True when persistence was performed
+function StateManager:saveNow()
+	if self._plugin and type(self._plugin.persistState) == "function" then
+		return self._plugin:persistState()
+	end
+	return false
+end
+
 --- Get the current settings data
 -- @return table Settings data table
 function StateManager:getSettings()

--- a/plugins/burrow.koplugin/burrow_store/core/sync_manager.lua
+++ b/plugins/burrow.koplugin/burrow_store/core/sync_manager.lua
@@ -294,7 +294,7 @@ function SyncManager.getSyncDownloadList(browser, url_arg)
 
 		-- Handle Project Gutenberg style entries
 		while #sub_table[count].acquisitions == 0 do
-			if util.stringEndsWith(sub_table[count].url, ".opds") then
+			if sub_table[count].url and util.stringEndsWith(sub_table[count].url, ".opds") then
 				acquisitions_empty = true
 				break
 			end

--- a/plugins/burrow.koplugin/burrow_store/core/sync_manager.lua
+++ b/plugins/burrow.koplugin/burrow_store/core/sync_manager.lua
@@ -18,6 +18,22 @@ local StateManager = require("burrow_store.core.state_manager")
 
 local SyncManager = {}
 
+local function persistSyncState()
+	local state = StateManager.getInstance()
+	state:markDirty()
+	state:saveNow()
+end
+
+local function activePendingCount(browser)
+	local count = 0
+	for _, item in ipairs(browser.pending_syncs or {}) do
+		if item.catalog and browser.sync_server_list and browser.sync_server_list[item.catalog] then
+			count = count + 1
+		end
+	end
+	return count
+end
+
 --- Show dialog to set maximum number of files to sync
 -- @param browser table OPDSBrowser instance
 function SyncManager.showMaxSyncDialog(browser)
@@ -35,7 +51,7 @@ function SyncManager.showMaxSyncDialog(browser)
 		ok_text = _("Save"),
 		callback = function(spin)
 			browser.settings.sync_max_dl = spin.value
-			StateManager.getInstance():markDirty()
+			persistSyncState()
 		end,
 	}
 	UIManager:show(spin)
@@ -53,7 +69,7 @@ function SyncManager.showSyncDirChooser(browser)
 		onConfirm = function(inbox)
 			logger.info("set opds sync folder", inbox)
 			browser.settings.sync_dir = inbox
-			StateManager.getInstance():markDirty()
+			persistSyncState()
 		end,
 	}:chooseDir(force_chooser_dir)
 end
@@ -83,7 +99,7 @@ function SyncManager.showFiletypesDialog(browser)
 					callback = function()
 						local str = dialog:getInputText()
 						browser.settings.filetypes = str ~= "" and str or nil
-						StateManager.getInstance():markDirty()
+						persistSyncState()
 						UIManager:close(dialog)
 					end,
 				},
@@ -104,7 +120,10 @@ function SyncManager.parseFiletypes(filetypes_str)
 
 	local file_list = {}
 	for filetype in util.gsplit(filetypes_str, ",") do
-		file_list[util.trim(filetype)] = true
+		local normalized = util.trim(filetype):lower()
+		if normalized ~= "" then
+			file_list[normalized] = true
+		end
 	end
 	return file_list
 end
@@ -121,27 +140,42 @@ function SyncManager.checkAndStartSync(browser, server_idx)
 	end
 
 	browser.sync = true
+	browser.sync_server_list = {}
 	local info = InfoMessage:new {
 		text = _("Synchronizing lists…"),
 	}
 	UIManager:show(info)
 	UIManager:forceRePaint()
 
+	local selected_count = 0
 	if server_idx then
-		-- Sync specific server (first item is "Downloads", so subtract 1)
-		SyncManager.fillPendingSyncs(browser, browser.servers[server_idx - 1])
+		-- Sync specific server (first item is "Downloads", so subtract 1).
+		local server = browser.servers[server_idx - 1]
+		if server then
+			selected_count = 1
+			SyncManager.fillPendingSyncs(browser, server)
+		end
 	else
-		-- Sync all servers with sync enabled
+		-- Sync all servers with sync enabled.
 		for _, server in ipairs(browser.servers) do
 			if server.sync then
+				selected_count = selected_count + 1
 				SyncManager.fillPendingSyncs(browser, server)
 			end
 		end
 	end
 
+	-- The pending list and each catalog's last_download marker are one logical
+	-- checkpoint. Persist them together before any worker starts downloading so
+	-- a restart can safely resume instead of forgetting pending work.
+	persistSyncState()
 	UIManager:close(info)
 
-	if #browser.pending_syncs > 0 then
+	if selected_count == 0 then
+		UIManager:show(InfoMessage:new {
+			text = _("No catalogs are enabled for sync."),
+		})
+	elseif activePendingCount(browser) > 0 then
 		Trapper:wrap(function()
 			SyncManager.downloadPendingSyncs(browser)
 		end)
@@ -170,6 +204,17 @@ function SyncManager.fillPendingSyncs(browser, server)
 	local file_list                = SyncManager.parseFiletypes(browser.settings.filetypes)
 	local new_last_download        = nil
 	local dl_count                 = 1
+	local has_pending_for_server   = false
+	local pending_keys             = {}
+
+	for _, pending in ipairs(browser.pending_syncs or {}) do
+		if pending.file and pending.url then
+			pending_keys[pending.file .. "\0" .. pending.url] = true
+		end
+		if pending.catalog == server.url then
+			has_pending_for_server = true
+		end
+	end
 
 	local sync_list                = SyncManager.getSyncDownloadList(browser)
 	if sync_list then
@@ -181,8 +226,8 @@ function SyncManager.fillPendingSyncs(browser, server)
 				sub_table = SyncManager.getSyncDownloadList(browser, entry.url) or {}
 			end
 			if #sub_table > 0 then
-				-- The first element seems to be most compatible. Second element has most options
-				item = sub_table[2]
+				-- The first element seems to be most compatible. Second element has most options.
+				item = sub_table[2] or sub_table[1]
 			else
 				item = entry
 			end
@@ -198,14 +243,19 @@ function SyncManager.fillPendingSyncs(browser, server)
 						local filename = browser:getFileName(entry)
 						local download_path = browser:getLocalDownloadPath(filename, filetype, link.href)
 						if dl_count <= browser.sync_max_dl then
-							table.insert(browser.pending_syncs, {
-								file = download_path,
-								url = link.href,
-								username = browser.root_catalog_username,
-								password = browser.root_catalog_password,
-								catalog = server.url,
-							})
-							dl_count = dl_count + 1
+							local pending_key = download_path .. "\0" .. link.href
+							if not pending_keys[pending_key] then
+								table.insert(browser.pending_syncs, {
+									file = download_path,
+									url = link.href,
+									username = browser.root_catalog_username,
+									password = browser.root_catalog_password,
+									catalog = server.url,
+								})
+								pending_keys[pending_key] = true
+								dl_count = dl_count + 1
+							end
+							has_pending_for_server = true
 						end
 						break
 					end
@@ -215,7 +265,7 @@ function SyncManager.fillPendingSyncs(browser, server)
 	end
 
 	browser.sync_server_list[server.url] = true
-	if new_last_download then
+	if new_last_download and has_pending_for_server then
 		logger.dbg("Updating opds last download for server", server.title, "to", new_last_download)
 		browser:updateFieldInCatalog(server, "last_download", new_last_download)
 	end

--- a/plugins/burrow.koplugin/burrow_store/core/sync_manager.lua
+++ b/plugins/burrow.koplugin/burrow_store/core/sync_manager.lua
@@ -34,6 +34,88 @@ local function activePendingCount(browser)
 	return count
 end
 
+local function itemHasDownloadableAcquisition(item)
+	for _, link in ipairs(item and item.acquisitions or {}) do
+		if DownloadManager.getFiletype(link) then
+			return true
+		end
+	end
+	return false
+end
+
+local function tableHasDownloadableAcquisitions(item_table)
+	for _, item in ipairs(item_table or {}) do
+		if itemHasDownloadableAcquisition(item) then
+			return true
+		end
+	end
+	return false
+end
+
+local function normalizeShelfTitle(item)
+	return tostring(item and (item.title or item.text) or ""):lower()
+end
+
+local function syncShelfScore(item, original_index)
+	local title = normalizeShelfTitle(item)
+	local score = 0
+
+	-- Prefer one canonical book shelf over index-style branches that fan the
+	-- same books out by author, series, category, genre, etc.
+	if title:find("all books", 1, true) then
+		score = 1000
+	elseif title == "books" or title:find(" books", 1, true) then
+		score = 900
+	elseif title:find("library", 1, true) then
+		score = 850
+	elseif title:find("recently added", 1, true) or title:find("newest", 1, true) then
+		score = 800
+	elseif title:find("latest", 1, true) or title:find("recent", 1, true) then
+		score = 750
+	end
+
+	if title:find("author", 1, true)
+		or title:find("series", 1, true)
+		or title:find("categor", 1, true)
+		or title:find("genre", 1, true)
+		or title:find("tag", 1, true) then
+		score = score - 1000
+	end
+
+	-- Preserve feed order as a tiebreaker.
+	return score - (original_index or 0) / 1000
+end
+
+local function findSyncShelf(browser, root_table)
+	local candidates = {}
+	for index, item in ipairs(root_table or {}) do
+		if item.url then
+			table.insert(candidates, {
+				item = item,
+				index = index,
+				score = syncShelfScore(item, index),
+			})
+		end
+	end
+
+	table.sort(candidates, function(a, b)
+		return a.score > b.score
+	end)
+
+	-- Only inspect immediate shelves. This deliberately avoids recursively
+	-- walking Authors/Series/Categories trees and downloading the same library
+	-- through many different paths.
+	for _, candidate in ipairs(candidates) do
+		local child_table = browser:genItemTableFromURL(candidate.item.url)
+		if tableHasDownloadableAcquisitions(child_table) then
+			logger.dbg("Using nested OPDS shelf for sync", candidate.item.text or candidate.item.title, candidate.item.url)
+			return candidate.item.url
+		end
+	end
+
+	return nil
+end
+
 --- Show dialog to set maximum number of files to sync
 -- @param browser table OPDSBrowser instance
 function SyncManager.showMaxSyncDialog(browser)
@@ -141,6 +223,7 @@ function SyncManager.checkAndStartSync(browser, server_idx)
 
 	browser.sync = true
 	browser.sync_server_list = {}
+	browser.sync_no_download_feed = {}
 	local info = InfoMessage:new {
 		text = _("Synchronizing lists…"),
 	}
@@ -180,9 +263,19 @@ function SyncManager.checkAndStartSync(browser, server_idx)
 			SyncManager.downloadPendingSyncs(browser)
 		end)
 	else
-		UIManager:show(InfoMessage:new {
-			text = _("Up to date!"),
-		})
+		local unresolved_count = 0
+		for _ in pairs(browser.sync_no_download_feed or {}) do
+			unresolved_count = unresolved_count + 1
+		end
+		if unresolved_count == selected_count then
+			UIManager:show(InfoMessage:new {
+				text = _("No downloadable book shelf was found in the selected catalog."),
+			})
+		else
+			UIManager:show(InfoMessage:new {
+				text = _("Up to date!"),
+			})
+		end
 	end
 
 	browser.sync = false
@@ -284,8 +377,23 @@ function SyncManager.getSyncDownloadList(browser, url_arg)
 	while #sync_table < browser.sync_max_dl and not up_to_date do
 		sub_table = browser:genItemTableFromURL(fetch_url)
 
-		-- Handle timeout
+		-- Handle timeout or empty feed.
 		if #sub_table == 0 then
+			return sync_table
+		end
+
+		-- Many modern OPDS servers expose a navigation/shelf feed at the saved
+		-- catalog URL. KOReader's inherited sync code only recognized one narrow
+		-- ".opds" subcatalog pattern, so servers such as DriveShelf could browse
+		-- normally while Sync saw zero books. Resolve one immediate canonical
+		-- book shelf and run normal pagination/checkpoint logic against it.
+		if not url_arg and not tableHasDownloadableAcquisitions(sub_table) then
+			local shelf_url = findSyncShelf(browser, sub_table)
+			if shelf_url then
+				return SyncManager.getSyncDownloadList(browser, shelf_url)
+			end
+			browser.sync_no_download_feed = browser.sync_no_download_feed or {}
+			browser.sync_no_download_feed[browser.sync_server.url] = true
 			return sync_table
 		end
 
@@ -310,7 +418,7 @@ function SyncManager.getSyncDownloadList(browser, url_arg)
 		if acquisitions_empty then
 			first_href = sub_table[count].url
 		else
-			first_href = sub_table[1].acquisitions[1].href
+			first_href = sub_table[count].acquisitions[1].href
 		end
 
 		if first_href == browser.sync_server.last_download and not browser.sync_force then
@@ -326,7 +434,7 @@ function SyncManager.getSyncDownloadList(browser, url_arg)
 					href = nil
 				end
 			else
-				href = entry.acquisitions[1].href
+				href = entry.acquisitions and entry.acquisitions[1] and entry.acquisitions[1].href or nil
 			end
 
 			if href then

--- a/plugins/burrow.koplugin/burrow_store/main.lua
+++ b/plugins/burrow.koplugin/burrow_store/main.lua
@@ -44,8 +44,8 @@ function OPDS:init()
     -- Initialize defaults
     settings_manager:initializeDefaults()
 
-    if settings_manager.is_first_run then
-        self.updated = true -- first run, force flush
+    if settings_manager.is_first_run or settings_manager.did_migrate then
+        self.updated = true -- first run or schema migration, force persistence
     end
 
     -- Initialize state manager singleton
@@ -57,10 +57,35 @@ function OPDS:init()
     self.pending_syncs = self.opds_settings:readSetting("pending_syncs", {})
     DownloadManager.repairDownloadQueue(self)
 
+    if self.updated then
+        self:persistState()
+    end
+
     if not self.embedded then
         self:onDispatcherRegisterActions()
         self.ui.menu:registerToMainMenu(self)
     end
+end
+
+function OPDS:persistState()
+    if not self.opds_settings then
+        return false
+    end
+
+    -- self.settings is the LuaSettings root table. Keep Store state tables
+    -- explicitly attached to that root, then flush once. Never save the root
+    -- table inside a nested "settings" key, which would create a cycle.
+    self.opds_settings:saveSetting("servers", self.servers or {})
+    self.opds_settings:saveSetting("downloads", self.downloads or {})
+    self.opds_settings:saveSetting("pending_syncs", self.pending_syncs or {})
+    self.opds_settings:flush()
+    self.updated = nil
+
+    local state = StateManager.getInstance()
+    if state then
+        state:markClean()
+    end
+    return true
 end
 
 function OPDS:getCoverHeightRatio()
@@ -70,8 +95,7 @@ end
 function OPDS:setCoverHeightRatio(ratio, preset_name)
     self.settings.cover_height_ratio = ratio
     self.settings.cover_size_preset = preset_name or "Custom"
-    self.opds_settings:saveSetting("settings", self.settings)
-    self.opds_settings:flush()
+    self:persistState()
 end
 
 function OPDS:getCurrentPresetName()
@@ -80,8 +104,7 @@ end
 
 function OPDS:saveSetting(key, value)
     self.settings[key] = value
-    self.opds_settings:saveSetting("settings", self.settings)
-    self.opds_settings:flush()
+    self:persistState()
 end
 
 function OPDS:getSetting(key)
@@ -213,6 +236,7 @@ function OPDS:_createBrowserInstance()
             end
             UIManager:close(self.opds_browser)
             self.opds_browser = nil
+            self:persistState()
             if self.last_downloaded_file then
                 if self.ui.file_chooser then
                     local pathname = util.splitFilePathName(self.last_downloaded_file)
@@ -322,9 +346,9 @@ function OPDS:showFileDownloadedDialog(file)
 end
 
 function OPDS:onFlushSettings()
-    if self.updated then
-        self.opds_settings:flush()
-        self.updated = nil
+    local state = StateManager.getInstance()
+    if self.updated or (state and state:isDirty()) then
+        self:persistState()
     end
 end
 

--- a/plugins/burrow.koplugin/burrow_store/ui/browser.lua
+++ b/plugins/burrow.koplugin/burrow_store/ui/browser.lua
@@ -302,13 +302,17 @@ function OPDSBrowser:editCatalogFromInput(fields, item, no_refresh)
     if should_refresh then
         self:switchItemTable(nil, self.item_table, itemnumber)
     end
-    StateManager.getInstance():markDirty()
+    local state = StateManager.getInstance()
+    state:markDirty()
+    state:saveNow()
 end
 
 function OPDSBrowser:deleteCatalog(item)
     self.item_table = CatalogManager.deleteCatalog(self.servers, self.item_table, item)
     self:switchItemTable(nil, self.item_table, -1)
-    StateManager.getInstance():markDirty()
+    local state = StateManager.getInstance()
+    state:markDirty()
+    state:saveNow()
 end
 
 function OPDSBrowser:fetchFeed(item_url, headers_only)
@@ -653,6 +657,10 @@ function OPDSBrowser:onCloseWidget()
         self._catalog_loading_overlay = nil
     end
     self._catalog_loading = false
+    local state = StateManager.getInstance()
+    if state:isDirty() then
+        state:saveNow()
+    end
     return OPDSCoverMenu.onCloseWidget(self)
 end
 

--- a/plugins/burrow.koplugin/burrow_version.lua
+++ b/plugins/burrow.koplugin/burrow_version.lua
@@ -1,7 +1,7 @@
 return {
-    VERSION = "0.4.6",
-    DISPLAY_VERSION = "0.4.6",
-    STORE_ENGINE_VERSION = "1.2.1",
+    VERSION = "0.4.7-beta.1",
+    DISPLAY_VERSION = "0.4.7-beta.1",
+    STORE_ENGINE_VERSION = "1.2.2",
 
     -- Burrow is tested against KOReader 2026.07.2. Older releases are blocked,
     -- but newer releases and nightlies are allowed with a one-time warning.

--- a/plugins/burrow.koplugin/burrow_version.lua
+++ b/plugins/burrow.koplugin/burrow_version.lua
@@ -1,7 +1,7 @@
 return {
-    VERSION = "0.4.7-beta.1",
-    DISPLAY_VERSION = "0.4.7-beta.1",
-    STORE_ENGINE_VERSION = "1.2.2",
+    VERSION = "0.4.7-beta.2",
+    DISPLAY_VERSION = "0.4.7-beta.2",
+    STORE_ENGINE_VERSION = "1.2.3",
 
     -- Burrow is tested against KOReader 2026.07.2. Older releases are blocked,
     -- but newer releases and nightlies are allowed with a one-time warning.


### PR DESCRIPTION
Promotes the Android-tested Burrow Store sync repair as `0.4.7-beta.2`.

Fixes:
- Persists sync folder, file types, max downloads, catalog sync flags, catalog edits, and credentials across KOReader restarts.
- Repairs the Store settings save path so the root settings table is never nested into itself.
- Persists pending sync work and `last_download` checkpoints together so interrupted syncs can resume safely.
- Prevents false `Up to date!` results when no catalogs are enabled.
- Resolves navigation-only OPDS roots to a canonical immediate book shelf so DriveShelf-style catalogs actually create download jobs.
- Avoids recursively crawling Authors, Series, Categories, Genres, and Tags.
- Handles mixed navigation/book feeds safely.

Validation:
- GitHub Lua validation passed.
- Updater regression validation passed.
- User tested `0.4.7-beta.2` successfully on Android and confirmed OPDS sync downloads work.