### PR TITLE
Promote Burrow 0.4.7 to stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Burrow will be documented here.
 
 ## [Unreleased]
 
+## [0.4.7] - 2026-09-02
+
+### Fixed
+
+- Made Burrow Store sync settings, catalog flags, credentials, pending work, and sync checkpoints persist safely across KOReader restarts.
+- Made OPDS sync discover a canonical immediate book shelf from navigation-only catalog roots, while avoiding recursive traversal through author, series, category, genre, and tag indexes.
+- Hardened mixed navigation/book OPDS feeds and restored safe file-type filtering and subcatalog fallback behavior.
+- Prevented false `Up to date!` results when no catalogs are enabled or when no downloadable book shelf can be found.
+- Preserved catalog sync cursors when editing settings and prevented duplicate or lost pending sync work across interrupted runs.
+- Refreshes the hero card as soon as background metadata and cover extraction finishes for newly synced books while keeping stale metadata and cover invalidation intact.
+
 ## [0.4.7-beta.3] - 2026-08-30
 
 ### Fixed

--- a/plugins/burrow.koplugin/burrow_version.lua
+++ b/plugins/burrow.koplugin/burrow_version.lua
@@ -1,6 +1,6 @@
 return {
-    VERSION = "0.4.7-beta.3",
-    DISPLAY_VERSION = "0.4.7-beta.3",
+    VERSION = "0.4.7",
+    DISPLAY_VERSION = "0.4.7",
     STORE_ENGINE_VERSION = "1.2.3",
 
     -- Burrow is tested against KOReader 2026.07.2. Older releases are blocked,


### PR DESCRIPTION
Stable promotion only. No behavior changes from the tested 0.4.7-beta.3 code.

Changes:
- VERSION/DISPLAY_VERSION: 0.4.7-beta.3 -> 0.4.7
- Add consolidated 0.4.7 stable changelog entry dated 2026-09-02

The package workflow will treat 0.4.7 as a normal release and mark it Latest.