### PR TITLE
Burrow 0.4.8 beta 1: simplified cover spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to Burrow will be documented here.
 
 ## [Unreleased]
 
+## [0.4.8-beta.1] - 2026-09-10
+
+### Added
+
+- Added independent horizontal and vertical cover-spacing controls under a single Cover spacing menu.
+- Added a two-direction spacing scale where `0` is normal, negative values tighten spacing, and positive values widen spacing.
+
+### Changed
+
+- Simplified the cover-spacing settings so cover size remains separate and horizontal/vertical spacing are grouped together.
+- Preserved existing `burrow_cover_gap_reduction` layouts by translating the legacy value to the equivalent new horizontal spacing when no new value has been saved.
+- Kept hero-card width aligned automatically to the final horizontal cover span while preserving its minimum safe composition width.
+
+### Fixed
+
+- Made cover spacing adjustable in both directions without changing cover size, grid dimensions, touch targets, captions, badges, physical-folder rendering, or automatic-series rendering.
+- Made vertical spacing operate on the rows actually visible on the current page so partial final pages are not shifted as if empty rows existed.
+
 ## [0.4.7] - 2026-09-02
 
 ### Fixed

--- a/plugins/burrow.koplugin/burrow_version.lua
+++ b/plugins/burrow.koplugin/burrow_version.lua
@@ -1,6 +1,6 @@
 return {
-    VERSION = "0.4.7",
-    DISPLAY_VERSION = "0.4.7",
+    VERSION = "0.4.8-beta.1",
+    DISPLAY_VERSION = "0.4.8-beta.1",
     STORE_ENGINE_VERSION = "1.2.3",
 
     -- Burrow is tested against KOReader 2026.07.2. Older releases are blocked,

--- a/plugins/burrow.koplugin/internal_patches/2-hero-card-grid-alignment.lua
+++ b/plugins/burrow.koplugin/internal_patches/2-hero-card-grid-alignment.lua
@@ -17,7 +17,7 @@ local function patchHeroGridAlignment(plugin)
     local UIManager = require("ui/uimanager")
     local logger = require("logger")
 
-    if CoverMenu._burrow_hero_grid_alignment_v1 then
+    if CoverMenu._burrow_hero_grid_alignment_v2 then
         return true
     end
 
@@ -105,12 +105,35 @@ local function patchHeroGridAlignment(plugin)
         return nil
     end
 
-    local function normalizeGap(value)
+    local function normalizeSpacing(value)
         value = tonumber(value) or 0
-        value = math.floor(value + 0.5)
+        value = round(value)
+        if value < -30 then value = -30 end
+        if value > 30 then value = 30 end
+        return value
+    end
+
+    local function normalizeLegacyGap(value)
+        value = tonumber(value) or 0
+        value = round(value)
         if value < 0 then value = 0 end
         if value > 30 then value = 30 end
         return value
+    end
+
+    local function horizontalSpacing()
+        local value = BookInfoManager:getSetting("burrow_cover_horizontal_spacing")
+        if value ~= nil then
+            return normalizeSpacing(value)
+        end
+        return -normalizeLegacyGap(BookInfoManager:getSetting("burrow_cover_gap_reduction"))
+    end
+
+    local function scaledSigned(value)
+        value = normalizeSpacing(value)
+        if value == 0 then return 0 end
+        local scaled = Screen:scaleBySize(math.abs(value))
+        return value < 0 and -scaled or scaled
     end
 
     local function alignedSideMargin(menu)
@@ -131,32 +154,28 @@ local function patchHeroGridAlignment(plugin)
             return default_side_margin
         end
 
-        -- Cover gap reduction shifts whole tiles inward toward the center.
-        -- Mirror the exact shift used by the final cover-layout paint wrapper.
-        local gap_step = Screen:scaleBySize(normalizeGap(
-            BookInfoManager:getSetting("burrow_cover_gap_reduction")
-        ))
+        -- Mirror the final cover-layout horizontal spacing exactly. Negative
+        -- values tighten the grid and positive values widen it. Legacy gap
+        -- reduction values are translated to their equivalent negative value.
+        local spacing_step = scaledSigned(horizontalSpacing())
         local center_column = (columns + 1) / 2
-        local first_shift = round((center_column - 1) * gap_step)
-        local last_shift = round((center_column - columns) * gap_step)
+        local first_shift = round((1 - center_column) * spacing_step)
+        local last_shift = round((columns - center_column) * spacing_step)
 
         -- Centers of the first and last grid tiles are separated by one item
         -- width plus one item margin per column step. Add the exact rendered
-        -- cover width, then apply the inward shifts from gap reduction.
+        -- cover width, then apply the current final horizontal spacing shifts.
         local cover_span = (columns - 1) * (item_width + item_margin)
             + last_shift - first_shift + cover_width
 
         local screen_width = Screen:getWidth()
         cover_span = math.max(1, math.min(screen_width, round(cover_span)))
 
-        -- Preserve the current horizontal hero on very narrow grids rather than
-        -- allowing its cover and text to overlap. Standard multi-column grids
-        -- align exactly; narrow layouts retain the existing safe card width.
+        -- Continue to follow cover spacing automatically, but keep enough room
+        -- for the hero's horizontal cover-and-text composition on narrow grids.
         local current_card_width = screen_width - 2 * default_side_margin
         local minimum_safe_width = math.min(current_card_width, Screen:scaleBySize(360))
-        if cover_span < minimum_safe_width then
-            return default_side_margin
-        end
+        cover_span = math.max(cover_span, minimum_safe_width)
 
         return math.max(0, round((screen_width - cover_span) / 2))
     end
@@ -194,7 +213,7 @@ local function patchHeroGridAlignment(plugin)
         Menu.updateItems = CoverMenu.updateItems
     end
 
-    CoverMenu._burrow_hero_grid_alignment_v1 = true
+    CoverMenu._burrow_hero_grid_alignment_v2 = true
     logger.info("Burrow hero grid alignment loaded")
     return true
 end

--- a/plugins/burrow.koplugin/internal_patches/2-z-burrow-cover-layout.lua
+++ b/plugins/burrow.koplugin/internal_patches/2-z-burrow-cover-layout.lua
@@ -5,24 +5,33 @@ local Module = { key = MODULE_KEY, phase = "instance", filename = "2-z-burrow-co
 package.loaded[MODULE_KEY] = Module
 
 --[[
-    Burrow Cover Gap and Size Controls v2
+    Burrow Cover Spacing and Size Controls v3
 
-    Adds two independent settings under Burrow display settings:
+    Adds two independent cover-spacing axes plus cover size:
 
-      Cover gap reduction
-        Moves complete tiles inward without changing the grid or touch targets.
+      Horizontal spacing
+        0 keeps normal placement. Negative values pull complete tiles closer
+        together and positive values spread them farther apart.
+
+      Vertical spacing
+        0 keeps normal placement. Negative values pull complete rows closer
+        together and positive values spread them farther apart.
 
       Cover size
         Resizes the primary cover inside book, real-folder, and virtual-series
         tiles. Book and series captions are deferred and repainted beneath the
         resized cover so an enlarged cover cannot paint over its title.
 
-    The size setting is applied after Burrow and the other cover patches
-    have finished building a tile. It therefore works with normal covers,
-    custom folder covers, stock folder art, and automatic series folders.
+    Spacing only changes where complete tiles are painted. It does not change
+    grid dimensions, cover size, touch targets, captions, badges, or the number
+    of rows and columns.
 
-    Restart KOReader after changing either setting. Remove older gap, spacing,
-    or cover-size patches before installing this file.
+    The previous burrow_cover_gap_reduction setting remains a compatibility
+    fallback. If no new horizontal setting exists, its value is translated to
+    the equivalent negative horizontal spacing so an upgrade preserves the
+    existing visible layout.
+
+    Restart KOReader after changing spacing or cover size.
 --]]
 
 local logger = require("logger")
@@ -44,15 +53,17 @@ local function patchBurrowCoverControls(plugin)
         return
     end
 
-    local GAP_SETTING_KEY = "burrow_cover_gap_reduction"
+    local LEGACY_GAP_SETTING_KEY = "burrow_cover_gap_reduction"
+    local HORIZONTAL_SPACING_SETTING_KEY = "burrow_cover_horizontal_spacing"
+    local VERTICAL_SPACING_SETTING_KEY = "burrow_cover_vertical_spacing"
     local SIZE_SETTING_KEY = "burrow_cover_size_percent"
     local SHOW_BOOK_TITLES_SETTING = "burrow_show_book_titles"
     local SHOW_FOLDER_TITLES_SETTING = "burrow_show_folder_titles"
     local SHOW_SERIES_TITLES_SETTING = "burrow_show_series_titles"
 
-    local DEFAULT_GAP = 0
-    local MIN_GAP = 0
-    local MAX_GAP = 30
+    local DEFAULT_SPACING = 0
+    local MIN_SPACING = -30
+    local MAX_SPACING = 30
 
     local DEFAULT_SIZE = 100
     local MIN_SIZE = 50
@@ -70,28 +81,78 @@ local function patchBurrowCoverControls(plugin)
         return math.ceil(value - 0.5)
     end
 
-    local function normalizeGap(value)
-        value = tonumber(value) or DEFAULT_GAP
-        value = math.floor(value + 0.5)
-        if value < MIN_GAP then value = MIN_GAP end
-        if value > MAX_GAP then value = MAX_GAP end
+    local function normalizeSpacing(value)
+        value = tonumber(value) or DEFAULT_SPACING
+        value = round(value)
+        if value < MIN_SPACING then value = MIN_SPACING end
+        if value > MAX_SPACING then value = MAX_SPACING end
+        return value
+    end
+
+    local function normalizeLegacyGap(value)
+        value = tonumber(value) or 0
+        value = round(value)
+        if value < 0 then value = 0 end
+        if value > 30 then value = 30 end
         return value
     end
 
     local function normalizeSize(value)
         value = tonumber(value) or DEFAULT_SIZE
-        value = math.floor(value + 0.5)
+        value = round(value)
         if value < MIN_SIZE then value = MIN_SIZE end
         if value > MAX_SIZE then value = MAX_SIZE end
         return value
     end
 
-    local function getGap()
-        return normalizeGap(BookInfoManager:getSetting(GAP_SETTING_KEY))
+    local function getHorizontalSpacing()
+        local value = BookInfoManager:getSetting(HORIZONTAL_SPACING_SETTING_KEY)
+        if value ~= nil then
+            return normalizeSpacing(value)
+        end
+        return -normalizeLegacyGap(BookInfoManager:getSetting(LEGACY_GAP_SETTING_KEY))
+    end
+
+    local function getVerticalSpacing()
+        return normalizeSpacing(BookInfoManager:getSetting(VERTICAL_SPACING_SETTING_KEY))
     end
 
     local function getCoverSize()
         return normalizeSize(BookInfoManager:getSetting(SIZE_SETTING_KEY))
+    end
+
+    local function scaledSigned(value)
+        value = normalizeSpacing(value)
+        if value == 0 then return 0 end
+        local scaled = Screen:scaleBySize(math.abs(value))
+        return value < 0 and -scaled or scaled
+    end
+
+    local function pageLocalIndex(menu, index)
+        local page = menu and tonumber(menu.page)
+        local perpage = menu and tonumber(menu.perpage)
+        if page and page >= 1 and perpage and perpage > 0 then
+            return index - (page - 1) * perpage
+        end
+        return index
+    end
+
+    local function visibleRowCount(menu, columns)
+        if not menu or not columns or columns < 1 then return nil end
+
+        local rows = tonumber(menu.nb_rows)
+        local page = tonumber(menu.page)
+        local perpage = tonumber(menu.perpage)
+        local item_table = menu.item_table
+        if type(item_table) ~= "table" or not page or page < 1 or not perpage or perpage < 1 then
+            return rows
+        end
+
+        local first_index = (page - 1) * perpage + 1
+        local remaining = #item_table - first_index + 1
+        if remaining <= 0 then return rows end
+        local page_count = math.min(perpage, remaining)
+        return math.max(1, math.ceil(page_count / columns))
     end
 
     local function isBook(item)
@@ -397,29 +458,39 @@ local function patchBurrowCoverControls(plugin)
         original_text_paint = TextWidget._burrow_cover_caption_original_paint or original_text_paint
     end
 
-    if not MosaicMenuItem._burrow_cover_gap_reduction_patched_v2 then
-        MosaicMenuItem._burrow_cover_gap_reduction_patched_v2 = true
+    if not MosaicMenuItem._burrow_cover_spacing_patched_v3 then
+        MosaicMenuItem._burrow_cover_spacing_patched_v3 = true
 
         local original_paint = MosaicMenuItem.paintTo
         function MosaicMenuItem:paintTo(bb, x, y)
-            local original_y = y
-            local reduction = getGap()
             local menu = self.menu
             local columns = menu and tonumber(menu.nb_cols)
             local index = self.entry and tonumber(self.entry.idx)
+            local local_index = index and pageLocalIndex(menu, index)
 
-            if reduction > 0 and columns and columns > 1 and index then
-                local column = ((index - 1) % columns) + 1
+            local horizontal_spacing = getHorizontalSpacing()
+            if horizontal_spacing ~= 0 and columns and columns > 1 and local_index and local_index > 0 then
+                local column = ((local_index - 1) % columns) + 1
                 local center_column = (columns + 1) / 2
-                local step = Screen:scaleBySize(reduction)
-                x = x + round((center_column - column) * step)
+                x = x + round((column - center_column) * scaledSigned(horizontal_spacing))
             end
 
+            local vertical_spacing = getVerticalSpacing()
+            if vertical_spacing ~= 0 and columns and columns > 0 and local_index and local_index > 0 then
+                local rows = visibleRowCount(menu, columns)
+                local row = math.floor((local_index - 1) / columns) + 1
+                if rows and rows > 1 and row <= rows then
+                    local center_row = (rows + 1) / 2
+                    y = y + round((row - center_row) * scaledSigned(vertical_spacing))
+                end
+            end
+
+            local tile_y = y
             local vertical_shift = tonumber(self._burrow_cover_vertical_shift) or 0
             active_caption_item = self
             self._burrow_cover_caption_deferred = nil
 
-            local ok, result = pcall(original_paint, self, bb, x, y - vertical_shift)
+            local ok, result = pcall(original_paint, self, bb, x, tile_y - vertical_shift)
             active_caption_item = nil
             if not ok then
                 error(result)
@@ -437,12 +508,12 @@ local function patchBurrowCoverControls(plugin)
                 -- an absolute y in frame.dimen, which previously allowed captions
                 -- to be placed through the cover.
                 local current_h = tonumber(self._burrow_cover_current_height) or 0
-                local cover_bottom = y - vertical_shift
+                local cover_bottom = tile_y - vertical_shift
                     + math.floor(((tonumber(self.height) or current_h) - current_h) / 2)
                     + current_h
 
                 local caption_y = cover_bottom + CAPTION_GAP
-                local lowest_y = original_y + (tonumber(self.height) or caption_size.h) - caption_size.h
+                local lowest_y = tile_y + (tonumber(self.height) or caption_size.h) - caption_size.h
                 if caption_y > lowest_y then
                     caption_y = lowest_y
                 end
@@ -455,15 +526,49 @@ local function patchBurrowCoverControls(plugin)
             return result
         end
 
-        logger.info("Burrow cover gap and safe caption placement loaded", getGap())
+        logger.info(
+            "Burrow cover spacing and safe caption placement loaded",
+            getHorizontalSpacing(),
+            getVerticalSpacing()
+        )
     end
 
-    if plugin._burrow_cover_controls_menu_patched_v2 then
+    if plugin._burrow_cover_controls_menu_patched_v3 then
         return
     end
-    plugin._burrow_cover_controls_menu_patched_v2 = true
+    plugin._burrow_cover_controls_menu_patched_v3 = true
 
     local original_add_to_main_menu = plugin.addToMainMenu
+
+    local function spacingAxisItem(text, setting_key, getter, axis_name)
+        return {
+            text_func = function()
+                return T(_("%1: %2"), text, getter())
+            end,
+            callback = function()
+                local SpinWidget = require("ui/widget/spinwidget")
+                UIManager:show(SpinWidget:new {
+                    title_text = axis_name,
+                    info_text = _("0 is normal. Negative values move covers closer together. Positive values add more space. Cover size and touch areas do not change. Restart KOReader after saving."),
+                    value = getter(),
+                    default_value = DEFAULT_SPACING,
+                    value_min = MIN_SPACING,
+                    value_max = MAX_SPACING,
+                    value_step = 2,
+                    value_hold_step = 5,
+                    ok_text = _("Save"),
+                    callback = function(spin)
+                        BookInfoManager:saveSetting(setting_key, normalizeSpacing(spin.value))
+                        local InfoMessage = require("ui/widget/infomessage")
+                        UIManager:show(InfoMessage:new {
+                            text = _("Cover spacing saved. Restart KOReader to apply it."),
+                            timeout = 3,
+                        })
+                    end,
+                })
+            end,
+        }
+    end
 
     function plugin:addToMainMenu(menu_items)
         original_add_to_main_menu(self, menu_items)
@@ -472,32 +577,22 @@ local function patchBurrowCoverControls(plugin)
         local items = root and root.sub_item_table
         if not items then return end
 
-        local gap_item = {
-            text_func = function()
-                return T(_("Cover gap reduction: %1"), getGap())
-            end,
-            callback = function()
-                local SpinWidget = require("ui/widget/spinwidget")
-                UIManager:show(SpinWidget:new {
-                    title_text = _("Cover gap reduction"),
-                    info_text = _("0 keeps normal placement. Higher values move complete book and folder tiles inward without changing their touch areas. Restart KOReader after saving."),
-                    value = getGap(),
-                    default_value = DEFAULT_GAP,
-                    value_min = MIN_GAP,
-                    value_max = MAX_GAP,
-                    value_step = 2,
-                    value_hold_step = 5,
-                    ok_text = _("Save"),
-                    callback = function(spin)
-                        BookInfoManager:saveSetting(GAP_SETTING_KEY, normalizeGap(spin.value))
-                        local InfoMessage = require("ui/widget/infomessage")
-                        UIManager:show(InfoMessage:new {
-                            text = _("Cover gap reduction saved. Restart KOReader to apply it."),
-                            timeout = 3,
-                        })
-                    end,
-                })
-            end,
+        local spacing_item = {
+            text = _("Cover spacing"),
+            sub_item_table = {
+                spacingAxisItem(
+                    _("Horizontal spacing"),
+                    HORIZONTAL_SPACING_SETTING_KEY,
+                    getHorizontalSpacing,
+                    _("Horizontal spacing")
+                ),
+                spacingAxisItem(
+                    _("Vertical spacing"),
+                    VERTICAL_SPACING_SETTING_KEY,
+                    getVerticalSpacing,
+                    _("Vertical spacing")
+                ),
+            },
         }
 
         local size_item = {
@@ -537,7 +632,7 @@ local function patchBurrowCoverControls(plugin)
             end
         end
 
-        table.insert(items, insert_at, gap_item)
+        table.insert(items, insert_at, spacing_item)
         table.insert(items, insert_at + 1, size_item)
     end
 end

--- a/plugins/burrow.koplugin/internal_patches/2-zz-burrow-settings-menu.lua
+++ b/plugins/burrow.koplugin/internal_patches/2-zz-burrow-settings-menu.lua
@@ -4,15 +4,15 @@ if existing_module then return existing_module end
 local Module = { key = MODULE_KEY, phase = "instance", filename = "2-zz-burrow-settings-menu.lua" }
 package.loaded[MODULE_KEY] = Module
 
--- Burrow settings cleanup v2.
+-- Burrow settings cleanup v3.
 -- Rebuild the user-facing menu around normal tasks instead of exposing the
 -- structure inherited from Cover Browser and individual Burrow patches.
 
 local function applySettingsCleanup(plugin)
-    if not plugin or plugin._burrow_settings_cleanup_v2_patched then
+    if not plugin or plugin._burrow_settings_cleanup_v3_patched then
         return true
     end
-    plugin._burrow_settings_cleanup_v2_patched = true
+    plugin._burrow_settings_cleanup_v3_patched = true
 
     local BookInfoManager = require("bookinfomanager")
     local BurrowLoader = require("burrow_loader")
@@ -23,7 +23,9 @@ local function applySettingsCleanup(plugin)
 
     local SERIES_SETTING = "automatic_series_grouping_enabled"
     local COVER_SIZE_SETTING = "burrow_cover_size_percent"
-    local COVER_GAP_SETTING = "burrow_cover_gap_reduction"
+    local LEGACY_COVER_GAP_SETTING = "burrow_cover_gap_reduction"
+    local COVER_HORIZONTAL_SPACING_SETTING = "burrow_cover_horizontal_spacing"
+    local COVER_VERTICAL_SPACING_SETTING = "burrow_cover_vertical_spacing"
     local SHOW_BOOK_TITLES_SETTING = "burrow_show_book_titles"
     local SHOW_FOLDER_TITLES_SETTING = "burrow_show_folder_titles"
     local SHOW_SERIES_TITLES_SETTING = "burrow_show_series_titles"
@@ -31,9 +33,9 @@ local function applySettingsCleanup(plugin)
     local DEFAULT_COVER_SIZE = 100
     local MIN_COVER_SIZE = 50
     local MAX_COVER_SIZE = 130
-    local DEFAULT_COVER_GAP = 0
-    local MIN_COVER_GAP = 0
-    local MAX_COVER_GAP = 30
+    local DEFAULT_COVER_SPACING = 0
+    local MIN_COVER_SPACING = -30
+    local MAX_COVER_SPACING = 30
     local RETURN_TILE_SETTING = "burrow_return_to_library_enabled"
 
     local function textOf(item)
@@ -171,10 +173,16 @@ local function applySettingsCleanup(plugin)
         }
     end
 
+    local function round(value)
+        if value >= 0 then
+            return math.floor(value + 0.5)
+        end
+        return math.ceil(value - 0.5)
+    end
 
     local function clampInteger(value, default_value, minimum, maximum)
         value = tonumber(value) or default_value
-        value = math.floor(value + 0.5)
+        value = round(value)
         return math.max(minimum, math.min(maximum, value))
     end
 
@@ -187,12 +195,32 @@ local function applySettingsCleanup(plugin)
         )
     end
 
-    local function getCoverGapReduction()
+    local function getHorizontalSpacing()
+        local value = BookInfoManager:getSetting(COVER_HORIZONTAL_SPACING_SETTING)
+        if value ~= nil then
+            return clampInteger(
+                value,
+                DEFAULT_COVER_SPACING,
+                MIN_COVER_SPACING,
+                MAX_COVER_SPACING
+            )
+        end
+
+        local legacy = clampInteger(
+            BookInfoManager:getSetting(LEGACY_COVER_GAP_SETTING),
+            0,
+            0,
+            30
+        )
+        return -legacy
+    end
+
+    local function getVerticalSpacing()
         return clampInteger(
-            BookInfoManager:getSetting(COVER_GAP_SETTING),
-            DEFAULT_COVER_GAP,
-            MIN_COVER_GAP,
-            MAX_COVER_GAP
+            BookInfoManager:getSetting(COVER_VERTICAL_SPACING_SETTING),
+            DEFAULT_COVER_SPACING,
+            MIN_COVER_SPACING,
+            MAX_COVER_SPACING
         )
     end
 
@@ -227,33 +255,58 @@ local function applySettingsCleanup(plugin)
         }
     end
 
-    local function coverSpacingItem()
+    local function spacingAxisItem(text, title, setting_name, getter)
         return {
             text_func = function()
-                return T(_("Space between covers: %1"), getCoverGapReduction())
+                return T(_("%1: %2"), text, getter())
             end,
-            help_text = _("0 keeps the normal spacing. Higher values pull neighboring covers closer together without changing their touch targets."),
             callback = function()
                 local SpinWidget = require("ui/widget/spinwidget")
                 UIManager:show(SpinWidget:new {
-                    title_text = _("Space between covers"),
-                    info_text = _("0 keeps the normal spacing. Increase the value to reduce the visible space between books and folders. Restart KOReader after saving."),
-                    value = getCoverGapReduction(),
-                    default_value = DEFAULT_COVER_GAP,
-                    value_min = MIN_COVER_GAP,
-                    value_max = MAX_COVER_GAP,
+                    title_text = title,
+                    info_text = _("0 is normal. Negative values move covers closer together. Positive values add more space. Cover size and touch areas do not change. Restart KOReader after saving."),
+                    value = getter(),
+                    default_value = DEFAULT_COVER_SPACING,
+                    value_min = MIN_COVER_SPACING,
+                    value_max = MAX_COVER_SPACING,
                     value_step = 2,
                     value_hold_step = 5,
                     ok_text = _("Save"),
                     callback = function(spin)
                         BookInfoManager:saveSetting(
-                            COVER_GAP_SETTING,
-                            clampInteger(spin.value, DEFAULT_COVER_GAP, MIN_COVER_GAP, MAX_COVER_GAP)
+                            setting_name,
+                            clampInteger(
+                                spin.value,
+                                DEFAULT_COVER_SPACING,
+                                MIN_COVER_SPACING,
+                                MAX_COVER_SPACING
+                            )
                         )
                         UIManager:askForRestart()
                     end,
                 })
             end,
+        }
+    end
+
+    local function coverSpacingMenu()
+        return {
+            text = _("Cover spacing"),
+            help_text = _("Adjust horizontal and vertical cover spacing independently. 0 is the normal Burrow layout."),
+            sub_item_table = {
+                spacingAxisItem(
+                    _("Horizontal"),
+                    _("Horizontal spacing"),
+                    COVER_HORIZONTAL_SPACING_SETTING,
+                    getHorizontalSpacing
+                ),
+                spacingAxisItem(
+                    _("Vertical"),
+                    _("Vertical spacing"),
+                    COVER_VERTICAL_SPACING_SETTING,
+                    getVerticalSpacing
+                ),
+            },
         }
     end
 
@@ -343,7 +396,7 @@ local function applySettingsCleanup(plugin)
         -- Build these entries directly so the cleanup menu does not depend on
         -- finding the older dynamically-labelled patch entries.
         append(view_items, coverSizeItem())
-        append(view_items, coverSpacingItem())
+        append(view_items, coverSpacingMenu())
         append(view_items, titlesUnderCoversMenu(self))
 
         local items_per_page = findItem(old_items, _("Items per page"))


### PR DESCRIPTION
Test branch for Burrow 0.4.8-beta.1.

Changes:
- Replaces the one-direction cover-gap control with a simple Cover spacing submenu.
- Adds independent Horizontal and Vertical spacing controls.
- Uses 0 as normal, negative values for tighter spacing, and positive values for wider spacing.
- Preserves existing burrow_cover_gap_reduction values as a compatibility fallback by translating them to equivalent negative horizontal spacing.
- Keeps cover size, row/column counts, touch targets, captions, badges, physical folders, and automatic-series tiles unchanged.
- Moves complete rendered tiles only.
- Updates hero-card alignment so it continues to follow the final horizontal cover span automatically.
- Bumps the test version to 0.4.8-beta.1.

This starts from exact 0.4.7 stable main at 990128cdb5a5d5cd7baf9bd22ff1ffb04aff8bdb.

Do not promote to stable until device testing confirms horizontal tightening/widening, vertical tightening/widening, partial pages, folders, series, captions, badges, and hero auto-alignment.