### PR TITLE
Burrow 0.4.8 beta 2: normalize zero spacing

### DIFF
--- a/plugins/burrow.koplugin/burrow_migration.lua
+++ b/plugins/burrow.koplugin/burrow_migration.lua
@@ -94,6 +94,19 @@ function BurrowMigration.migrateSettings(BookInfoManager)
         end
     end
 
+    -- 0.4.8 replaced the one-way gap-reduction value with signed horizontal
+    -- spacing. Persist the equivalent new value once so the compatibility
+    -- fallback never has to expose Lua's numeric -0 in the settings menu.
+    -- Existing 0.4.8 users who already saved a horizontal value are untouched.
+    if BookInfoManager:getSetting("burrow_cover_horizontal_spacing") == nil then
+        local legacy_gap = tonumber(BookInfoManager:getSetting("burrow_cover_gap_reduction"))
+        if legacy_gap ~= nil then
+            legacy_gap = math.max(0, math.min(30, math.floor(legacy_gap + 0.5)))
+            local horizontal_spacing = legacy_gap == 0 and 0 or -legacy_gap
+            BookInfoManager:saveSetting("burrow_cover_horizontal_spacing", horizontal_spacing)
+        end
+    end
+
     for legacy_key, burrow_key in pairs(global_setting_map) do
         if G_reader_settings:readSetting(burrow_key) == nil then
             local legacy_value = G_reader_settings:readSetting(legacy_key)

--- a/plugins/burrow.koplugin/burrow_version.lua
+++ b/plugins/burrow.koplugin/burrow_version.lua
@@ -1,6 +1,6 @@
 return {
-    VERSION = "0.4.8-beta.1",
-    DISPLAY_VERSION = "0.4.8-beta.1",
+    VERSION = "0.4.8-beta.2",
+    DISPLAY_VERSION = "0.4.8-beta.2",
     STORE_ENGINE_VERSION = "1.2.3",
 
     -- Burrow is tested against KOReader 2026.07.2. Older releases are blocked,


### PR DESCRIPTION
Fixes the signed-zero display seen as `Horizontal: -0` after upgrading to the new cover-spacing controls.

The fix is intentionally narrow:
- Migrates the legacy one-way gap value into the new horizontal-spacing setting once.
- Legacy `0` is stored as real `0` instead of `-0`.
- Legacy nonzero values remain compatible, e.g. `10` becomes `-10`.
- Existing users who already saved a new horizontal-spacing value are untouched.
- No cover geometry, vertical spacing, touch target, caption, badge, folder, series, or hero behavior changes.
- Bumps the beta version to 0.4.8-beta.2.

Starts from 0.4.8-beta.1 main at `134b6dcfab0b981b8796ae30ce05e65444360973`.