### PR TITLE
Burrow 0.4.8 beta 3: center Home pager on first render

### DIFF
--- a/plugins/burrow.koplugin/burrow_settings.lua
+++ b/plugins/burrow.koplugin/burrow_settings.lua
@@ -178,6 +178,13 @@ function BurrowSettings:getModuleManifest()
             feature = "home_store",
             depends = { "library_core" },
         })
+        -- Keep first-render pager centering isolated from the base Home/Store
+        -- footer so a layout-specific regression cannot quarantine navigation.
+        add("home_store_pager_layout", "2-home-store-pager-layout.lua", "instance", {
+            filename = "2-home-store-pager-layout.lua",
+            feature = "home_store_pager_layout",
+            depends = { "home_store_footer" },
+        })
     end
 
     -- Kindle can preserve a stale hardware inversion flag across a KOReader

--- a/plugins/burrow.koplugin/burrow_version.lua
+++ b/plugins/burrow.koplugin/burrow_version.lua
@@ -1,6 +1,6 @@
 return {
-    VERSION = "0.4.8-beta.2",
-    DISPLAY_VERSION = "0.4.8-beta.2",
+    VERSION = "0.4.8-beta.3",
+    DISPLAY_VERSION = "0.4.8-beta.3",
     STORE_ENGINE_VERSION = "1.2.3",
 
     -- Burrow is tested against KOReader 2026.07.2. Older releases are blocked,

--- a/plugins/burrow.koplugin/internal_patches/2-home-store-pager-layout.lua
+++ b/plugins/burrow.koplugin/internal_patches/2-home-store-pager-layout.lua
@@ -1,0 +1,88 @@
+local MODULE_KEY = "burrow.internal.2_home_store_pager_layout"
+local existing_module = package.loaded[MODULE_KEY]
+if existing_module then return existing_module end
+
+local Module = {
+    key = MODULE_KEY,
+    phase = "instance",
+    filename = "2-home-store-pager-layout.lua",
+}
+package.loaded[MODULE_KEY] = Module
+
+-- Keep the Home page indicator centered from its very first render.
+--
+-- The Home/Store footer can be constructed while its PageDots child still has
+-- an earlier page count. PageDots updates itself later, but VerticalGroup may
+-- retain the child offset calculated from the old width until another page
+-- navigation causes a layout pass. This layer invalidates only the custom
+-- footer geometry when the rendered dot-group width changes.
+
+local function applyHomePagerLayoutFix()
+    local CoverMenu = require("covermenu")
+    local Menu = require("ui/widget/menu")
+
+    if CoverMenu._burrow_home_store_pager_layout_patched then
+        return true
+    end
+
+    local original_menu_init = CoverMenu.menuInit
+    local original_update_page_info = CoverMenu.updatePageInfo
+    local menu_was_using_covermenu_init = Menu.init == original_menu_init
+    local menu_was_using_covermenu_update = Menu.updatePageInfo == original_update_page_info
+
+    local function resetIfDotWidthChanged(menu)
+        local state = menu and menu._home_store_state
+        if not state or not menu._home_store_active or not state.dots then
+            return
+        end
+
+        local ok, size = pcall(state.dots.getSize, state.dots)
+        local width = ok and size and tonumber(size.w) or nil
+        if not width or state._burrow_home_pager_dot_width == width then
+            return
+        end
+        state._burrow_home_pager_dot_width = width
+
+        -- The dots themselves already know the current page/page count. Only
+        -- their parent alignment caches need to be rebuilt so the new width is
+        -- centered immediately. Fixed footer dimensions and navigation widgets
+        -- are left unchanged.
+        if state.custom_root and state.custom_root.resetLayout then
+            state.custom_root:resetLayout()
+        end
+        if state.custom_container and state.custom_container.resetLayout then
+            state.custom_container:resetLayout()
+        end
+        if state.page_controls and state.page_controls.resetLayout then
+            state.page_controls:resetLayout()
+        end
+        if state.footer and state.footer.resetLayout then
+            state.footer:resetLayout()
+        end
+    end
+
+    function CoverMenu:menuInit(...)
+        local result = original_menu_init(self, ...)
+        resetIfDotWidthChanged(self)
+        return result
+    end
+
+    function CoverMenu:updatePageInfo(...)
+        local result = original_update_page_info(self, ...)
+        resetIfDotWidthChanged(self)
+        return result
+    end
+
+    if menu_was_using_covermenu_init then
+        Menu.init = CoverMenu.menuInit
+    end
+    if menu_was_using_covermenu_update then
+        Menu.updatePageInfo = CoverMenu.updatePageInfo
+    end
+
+    CoverMenu._burrow_home_store_pager_layout_patched = true
+    return true
+end
+
+Module.apply = applyHomePagerLayoutFix
+return Module


### PR DESCRIPTION
Fixes the Home page indicator being offset on the initial Home render and then centering only after the first page turn.

Cause:
- The Home/Store footer can be built before PageDots has its final page count.
- PageDots later updates to its real width, but the parent alignment can retain the earlier cached child offset until another page navigation triggers layout.

Fix:
- Adds a small isolated Home pager layout layer after the existing Home/Store footer.
- Tracks the rendered PageDots width.
- When that width changes, resets only the custom footer alignment/layout caches so the dots are centered immediately.
- Does not rebuild or replace Home/Store navigation.
- Does not change page navigation, cover grid geometry, cover spacing, hero behavior, Store behavior, or reader behavior.
- Keeps this correction in its own feature group so a layout-specific failure cannot quarantine the base Home/Store footer.
- Bumps the beta version to 0.4.8-beta.3.

Starts from the Kindle-and-Android-tested 0.4.8-beta.2 main commit `508e4db982a80f53d9f2a89a4cde03b5bfd88d47`.

Device test before stable: cold/open Home on a multipage library and confirm the page dots are centered before any page turn, then verify they remain centered while paging.