### PR TITLE
Burrow 0.4.8 beta 5: silent offline KOSync suspend

### DIFF
--- a/plugins/burrow.koplugin/burrow_version.lua
+++ b/plugins/burrow.koplugin/burrow_version.lua
@@ -1,6 +1,6 @@
 return {
-    VERSION = "0.4.8-beta.4",
-    DISPLAY_VERSION = "0.4.8-beta.4",
+    VERSION = "0.4.8-beta.5",
+    DISPLAY_VERSION = "0.4.8-beta.5",
     STORE_ENGINE_VERSION = "1.2.3",
 
     -- Burrow is tested against KOReader 2026.07.2. Older releases are blocked,

--- a/plugins/burrow.koplugin/internal_patches/2-kindle-wifi-recovery.lua
+++ b/plugins/burrow.koplugin/internal_patches/2-kindle-wifi-recovery.lua
@@ -25,6 +25,13 @@ package.loaded[MODULE_KEY] = Module
     backend to authenticate it. There are deliberately no dialogs, toasts, or
     failure messages in this automatic path.
 
+    KOReader Progress Sync has a separate suspend path which deliberately calls
+    updateProgress with ensure_networking=true. When a Kindle is out of range,
+    that path calls willRerunWhenOnline(), which invokes the full Kindle Wi-Fi
+    connection flow and shows the "Scanning for networks" UI. Burrow detects only
+    that KOSync-on-suspend call and lets the progress request proceed offline;
+    KOSync then uses its existing retry queue and drains it on NetworkConnected.
+
     Important behavior:
     - Kindle only. Other devices are untouched.
     - Manual Wi-Fi actions remain KOReader's normal visible/interactive path.
@@ -33,6 +40,8 @@ package.loaded[MODULE_KEY] = Module
     - Explicit/manual Wi-Fi off still clears that intent through KOReader.
     - Only one silent scan is scheduled per restore call, with a short cooldown
       to avoid duplicate work during rapid lifecycle events.
+    - KOSync suspend never forces a visible connection attempt while offline;
+      its own retry queue preserves the progress update for later.
 --]]
 
 function Module.apply()
@@ -48,7 +57,7 @@ function Module.apply()
     local UIManager = require("ui/uimanager")
     local logger = require("logger")
 
-    if NetworkMgr._burrow_kindle_wifi_recovery_v1 then
+    if NetworkMgr._burrow_kindle_wifi_recovery_v2 then
         Module.applied = true
         return true
     end
@@ -60,6 +69,7 @@ function Module.apply()
     local original_disable = NetworkMgr.disableWifi
     local original_toggle_on = NetworkMgr.toggleWifiOn
     local original_toggle_off = NetworkMgr.toggleWifiOff
+    local original_will_rerun_when_online = NetworkMgr.willRerunWhenOnline
 
     if type(original_restore) ~= "function"
         or type(original_abort) ~= "function"
@@ -68,6 +78,7 @@ function Module.apply()
         or type(original_disable) ~= "function"
         or type(original_toggle_on) ~= "function"
         or type(original_toggle_off) ~= "function"
+        or type(original_will_rerun_when_online) ~= "function"
         or type(NetworkMgr.getNetworkList) ~= "function"
         or type(NetworkMgr.authenticateNetwork) ~= "function"
     then
@@ -89,6 +100,31 @@ function Module.apply()
     local function clearAutomaticRestore(self)
         cancelScheduledRecovery(self)
         self._burrow_kindle_auto_restore_active = false
+    end
+
+    local function isKOSyncSuspendNetworkingCall()
+        -- Called from NetworkMgr:willRerunWhenOnline. Inspect only its immediate
+        -- caller and require both the KOSync source file and the named
+        -- on_suspend=true local. This keeps the behavior scoped to KOReader's
+        -- suspend autosync path instead of changing normal network-required
+        -- actions, manual Push/Pull, Store, updater, or other plugins.
+        local info = debug.getinfo(2, "S")
+        local source = info and info.source or ""
+        if not source:find("plugins/kosync%.koplugin/main%.lua", 1, false) then
+            return false
+        end
+
+        local index = 1
+        while true do
+            local name, value = debug.getlocal(2, index)
+            if not name then break end
+            if name == "on_suspend" then
+                return value == true
+            end
+            index = index + 1
+        end
+
+        return false
     end
 
     local function silentRecover(self)
@@ -256,6 +292,18 @@ function Module.apply()
         return original_toggle_off(self, complete_callback, interactive)
     end
 
+    function NetworkMgr:willRerunWhenOnline(callback)
+        if not self:isOnline() and isKOSyncSuspendNetworkingCall() then
+            -- Returning false tells KOSync to continue its non-interactive
+            -- updateProgress call without bringing Wi-Fi up. The network request
+            -- will naturally fail as unreachable and KOSync will queue that
+            -- progress update for its existing NetworkConnected drain path.
+            logger.dbg("Burrow Kindle Wi-Fi recovery: KOSync suspend is offline; queueing progress without Wi-Fi scan")
+            return false
+        end
+        return original_will_rerun_when_online(self, callback)
+    end
+
     -- NetworkMgr is initialized before Burrow's early modules are applied. If
     -- KOReader already began an automatic startup restore, join that in-flight
     -- attempt so the first launch after updating receives the same silent scan
@@ -272,6 +320,7 @@ function Module.apply()
     end
 
     NetworkMgr._burrow_kindle_wifi_recovery_v1 = true
+    NetworkMgr._burrow_kindle_wifi_recovery_v2 = true
     Module.applied = true
     logger.info("Burrow Kindle silent Wi-Fi recovery loaded")
     return true

--- a/plugins/burrow.koplugin/internal_patches/2-kindle-wifi-recovery.lua
+++ b/plugins/burrow.koplugin/internal_patches/2-kindle-wifi-recovery.lua
@@ -103,12 +103,13 @@ function Module.apply()
     end
 
     local function isKOSyncSuspendNetworkingCall()
-        -- Called from NetworkMgr:willRerunWhenOnline. Inspect only its immediate
-        -- caller and require both the KOSync source file and the named
-        -- on_suspend=true local. This keeps the behavior scoped to KOReader's
-        -- suspend autosync path instead of changing normal network-required
-        -- actions, manual Push/Pull, Store, updater, or other plugins.
-        local info = debug.getinfo(2, "S")
+        -- This helper is called from Burrow's NetworkMgr:willRerunWhenOnline
+        -- wrapper, so the KOSync updateProgress frame is three levels up:
+        -- KOSync:updateProgress -> willRerunWhenOnline -> this helper.
+        -- Require both the KOSync source file and the named on_suspend=true local
+        -- so normal network-required actions, manual Push/Pull, Store, updater,
+        -- and other plugins keep KOReader's native behavior.
+        local info = debug.getinfo(3, "S")
         local source = info and info.source or ""
         if not source:find("plugins/kosync%.koplugin/main%.lua", 1, false) then
             return false
@@ -116,7 +117,7 @@ function Module.apply()
 
         local index = 1
         while true do
-            local name, value = debug.getlocal(2, index)
+            local name, value = debug.getlocal(3, index)
             if not name then break end
             if name == "on_suspend" then
                 return value == true
@@ -293,7 +294,7 @@ function Module.apply()
     end
 
     function NetworkMgr:willRerunWhenOnline(callback)
-        if not self:isOnline() and isKOSyncSuspendNetworkingCall() then
+        if isKOSyncSuspendNetworkingCall() and not self:isOnline() then
             -- Returning false tells KOSync to continue its non-interactive
             -- updateProgress call without bringing Wi-Fi up. The network request
             -- will naturally fail as unreachable and KOSync will queue that


### PR DESCRIPTION
Kindle-only follow-up to beta 4.

Root cause found:
- KOReader Progress Sync has its own `onSuspend()` path.
- With automatic progress sync enabled, it calls `updateProgress(true, false, true)`.
- `ensure_networking=true` means an offline Kindle calls `NetworkMgr:willRerunWhenOnline()` during suspend.
- On Kindle that reaches the full `turnOnWifi()` / `reconnectOrShowNetworkMenu()` path, which displays `Scanning for networks…` even though the user is simply putting the device to sleep away from Wi-Fi.

Beta 5 change:
- Keep beta 4's Kindle-only silent resume recovery intact.
- Detect only the KOReader Progress Sync suspend call to `willRerunWhenOnline`.
- If that specific suspend call is offline, do not bring Wi-Fi up.
- Let KOSync continue its non-interactive update offline so its existing network-error path queues the progress update.
- KOSync already drains that retry queue on `NetworkConnected`, so progress is preserved for the next real connection.

Not changed:
- Manual Push/Pull still may request networking normally.
- Manual Wi-Fi remains visible and interactive.
- Store/updater/network-required actions are unchanged.
- Kindle resume auto-recovery from beta 4 remains enabled.
- Android and all non-Kindle devices are untouched.

Device test:
1. Enable KOReader automatic progress sync.
2. Leave home with Wi-Fi still intended to remain enabled.
3. Wake Kindle out of range, then suspend it again. There should be no `Scanning for networks…` popup during suspend.
4. Repeat wake/suspend a few times while still out of range; it should remain quiet.
5. Return to known Wi-Fi and wake. Beta 4 recovery should reconnect silently.
6. Confirm queued KOSync progress drains after reconnection.
7. Confirm manual Quick Settings Wi-Fi and manual Push/Pull still behave normally.