### PR TITLE
Burrow 0.4.8 beta 6: reject collapsed publisher page maps

### DIFF
--- a/plugins/burrow.koplugin/burrow_version.lua
+++ b/plugins/burrow.koplugin/burrow_version.lua
@@ -1,6 +1,6 @@
 return {
-    VERSION = "0.4.8-beta.5",
-    DISPLAY_VERSION = "0.4.8-beta.5",
+    VERSION = "0.4.8-beta.6",
+    DISPLAY_VERSION = "0.4.8-beta.6",
     STORE_ENGINE_VERSION = "1.2.3",
 
     -- Burrow is tested against KOReader 2026.07.2. Older releases are blocked,

--- a/plugins/burrow.koplugin/internal_patches/2-stable-page-numbers.lua
+++ b/plugins/burrow.koplugin/internal_patches/2-stable-page-numbers.lua
@@ -78,8 +78,8 @@ function Module.apply()
     -- collapsed. Labels themselves are not inspected: Roman numerals, duplicate
     -- labels, unusual numbering schemes and partial front matter are all valid.
     --
-    -- We deliberately require a reasonably large map and document. Then we use
-    -- two independent, conservative signals:
+    -- We deliberately require a large map and document. Then we use two
+    -- independent, conservative signals:
     --   1. almost all map entries literally reuse one or two XPointers; or
     --   2. anchors sampled across the entire map all resolve into essentially the
     --      same tiny rendered-page span.
@@ -93,13 +93,13 @@ function Module.apply()
         end
 
         local total = #page_list
-        if total < 20 then
+        if total < 40 then
             return false
         end
 
         local ok_pages, rendered_pages = pcall(document.getPages, document)
         rendered_pages = ok_pages and tonumber(rendered_pages) or 0
-        if not rendered_pages or rendered_pages < 20 then
+        if not rendered_pages or rendered_pages < 40 then
             return false
         end
 
@@ -117,8 +117,8 @@ function Module.apply()
             end
         end
 
-        if xpointer_count >= 20 then
-            local duplicate_limit = math.max(2, math.floor(xpointer_count * 0.05))
+        if xpointer_count >= 40 then
+            local duplicate_limit = math.max(2, math.floor(xpointer_count * 0.03))
             if unique_xpointer_count <= duplicate_limit then
                 return true, string.format(
                     "%d page-map entries use only %d distinct anchors",
@@ -153,9 +153,9 @@ function Module.apply()
             end
         end
 
-        if resolved_count >= 6 and min_page and max_page then
+        if resolved_count >= 7 and min_page and max_page then
             local span = max_page - min_page
-            local collapsed_span = math.max(2, math.floor(rendered_pages * 0.02))
+            local collapsed_span = math.max(2, math.floor(rendered_pages * 0.01))
             if span <= collapsed_span then
                 return true, string.format(
                     "%d sampled anchors span only %d of %d rendered pages",

--- a/plugins/burrow.koplugin/internal_patches/2-stable-page-numbers.lua
+++ b/plugins/burrow.koplugin/internal_patches/2-stable-page-numbers.lua
@@ -13,15 +13,161 @@ function Module.apply()
     if Module.applied then return true end
 
     local ReaderPageMap = require("apps/reader/modules/readerpagemap")
-    if ReaderPageMap._burrow_stable_page_numbers_v1 then
+    local logger = require("logger")
+    if ReaderPageMap._burrow_stable_page_numbers_v2 then
         Module.applied = true
         return true
     end
     ReaderPageMap._burrow_stable_page_numbers_v1 = true
+    ReaderPageMap._burrow_stable_page_numbers_v2 = true
 
     local DEFAULT_CHARS_PER_PAGE = 1500
     local original_onReadSettings = ReaderPageMap.onReadSettings
     local original_postInit = ReaderPageMap._postInit
+
+    local function getSyntheticChars(self)
+        local chars = tonumber(
+            self.ui.doc_settings:readSetting("pagemap_chars_per_synthetic_page")
+            or G_reader_settings:readSetting("pagemap_chars_per_synthetic_page")
+            or self.chars_per_synthetic_page
+            or self.chars_per_synthetic_page_default
+            or DEFAULT_CHARS_PER_PAGE
+        ) or DEFAULT_CHARS_PER_PAGE
+
+        if chars < 500 then chars = 500 end
+        if chars > 3000 then chars = 3000 end
+        return chars
+    end
+
+    local function installSyntheticMap(self, document, chars, register_view)
+        local ok, err = pcall(document.buildSyntheticPageMap, document, chars)
+        if not ok then
+            logger.warn("Burrow stable page numbers: synthetic page-map build failed", err)
+            return false
+        end
+        if not document:hasPageMap() then
+            logger.warn("Burrow stable page numbers: synthetic page-map build returned no map")
+            return false
+        end
+
+        self.chars_per_synthetic_page = chars
+        self.has_pagemap = true
+        self.page_labels_cache = nil
+        self:resetLayout()
+        if register_view then
+            self.view:registerViewModule("pagemap", self)
+        end
+        self.ui.doc_settings:saveSetting("pagemap_chars_per_synthetic_page", chars)
+        self.ui.doc_settings:saveSetting(
+            "pagemap_doc_pages",
+            select(3, self:getCurrentPageLabel())
+        )
+        return true
+    end
+
+    local function addSampleIndex(indices, seen, index, total)
+        if index < 1 then index = 1 end
+        if index > total then index = total end
+        if not seen[index] then
+            seen[index] = true
+            indices[#indices + 1] = index
+        end
+    end
+
+    -- A publisher map is considered broken only when its anchors are objectively
+    -- collapsed. Labels themselves are not inspected: Roman numerals, duplicate
+    -- labels, unusual numbering schemes and partial front matter are all valid.
+    --
+    -- We deliberately require a reasonably large map and document. Then we use
+    -- two independent, conservative signals:
+    --   1. almost all map entries literally reuse one or two XPointers; or
+    --   2. anchors sampled across the entire map all resolve into essentially the
+    --      same tiny rendered-page span.
+    --
+    -- This catches maps that report hundreds of entries while every reading
+    -- position resolves to one early label, without second-guessing healthy maps.
+    local function publisherMapClearlyCollapsed(document)
+        local ok, page_list = pcall(document.getPageMap, document)
+        if not ok or type(page_list) ~= "table" then
+            return false
+        end
+
+        local total = #page_list
+        if total < 20 then
+            return false
+        end
+
+        local ok_pages, rendered_pages = pcall(document.getPages, document)
+        rendered_pages = ok_pages and tonumber(rendered_pages) or 0
+        if not rendered_pages or rendered_pages < 20 then
+            return false
+        end
+
+        local xpointer_count = 0
+        local unique_xpointers = {}
+        local unique_xpointer_count = 0
+        for _, entry in ipairs(page_list) do
+            local xp = type(entry) == "table" and entry.xpointer or nil
+            if type(xp) == "string" and xp ~= "" then
+                xpointer_count = xpointer_count + 1
+                if not unique_xpointers[xp] then
+                    unique_xpointers[xp] = true
+                    unique_xpointer_count = unique_xpointer_count + 1
+                end
+            end
+        end
+
+        if xpointer_count >= 20 then
+            local duplicate_limit = math.max(2, math.floor(xpointer_count * 0.05))
+            if unique_xpointer_count <= duplicate_limit then
+                return true, string.format(
+                    "%d page-map entries use only %d distinct anchors",
+                    xpointer_count,
+                    unique_xpointer_count
+                )
+            end
+        end
+
+        local indices = {}
+        local seen = {}
+        for step = 0, 8 do
+            local index = 1 + math.floor((total - 1) * step / 8)
+            addSampleIndex(indices, seen, index, total)
+        end
+        table.sort(indices)
+
+        local resolved_count = 0
+        local min_page
+        local max_page
+        for _, index in ipairs(indices) do
+            local entry = page_list[index]
+            local xp = type(entry) == "table" and entry.xpointer or nil
+            if type(xp) == "string" and xp ~= "" then
+                local resolved_ok, page = pcall(document.getPageFromXPointer, document, xp)
+                page = resolved_ok and tonumber(page) or nil
+                if page then
+                    resolved_count = resolved_count + 1
+                    if not min_page or page < min_page then min_page = page end
+                    if not max_page or page > max_page then max_page = page end
+                end
+            end
+        end
+
+        if resolved_count >= 6 and min_page and max_page then
+            local span = max_page - min_page
+            local collapsed_span = math.max(2, math.floor(rendered_pages * 0.02))
+            if span <= collapsed_span then
+                return true, string.format(
+                    "%d sampled anchors span only %d of %d rendered pages",
+                    resolved_count,
+                    span,
+                    rendered_pages
+                )
+            end
+        end
+
+        return false
+    end
 
     -- Stable labels should be the normal Burrow presentation for reflowable
     -- documents. Do not touch fixed-layout readers (PDF/CBZ/DjVu/etc.).
@@ -43,34 +189,32 @@ function Module.apply()
 
         local document = self.ui.document
 
-        -- If KOReader already has a page map, leave its source alone. This keeps
-        -- publisher-supplied page maps intact and also respects an existing
-        -- user-selected synthetic map.
-        if not self.has_pagemap then
-            local chars = tonumber(
-                self.ui.doc_settings:readSetting("pagemap_chars_per_synthetic_page")
-                or G_reader_settings:readSetting("pagemap_chars_per_synthetic_page")
-                or self.chars_per_synthetic_page
-                or self.chars_per_synthetic_page_default
-                or DEFAULT_CHARS_PER_PAGE
-            ) or DEFAULT_CHARS_PER_PAGE
-
-            if chars < 500 then chars = 500 end
-            if chars > 3000 then chars = 3000 end
-
-            local ok = pcall(document.buildSyntheticPageMap, document, chars)
-            if ok and document:hasPageMap() then
-                self.chars_per_synthetic_page = chars
-                self.has_pagemap = true
-                self.page_labels_cache = nil
-                self:resetLayout()
-                self.view:registerViewModule("pagemap", self)
-                self.ui.doc_settings:saveSetting("pagemap_chars_per_synthetic_page", chars)
-                self.ui.doc_settings:saveSetting(
-                    "pagemap_doc_pages",
-                    select(3, self:getCurrentPageLabel())
+        -- KOReader normally prefers a publisher-supplied page map. Keep that
+        -- preference unless the publisher map is clearly collapsed. A synthetic
+        -- map already selected by the user is never validated or replaced here.
+        if self.has_pagemap
+            and self.has_pagemap_document_provided
+            and not self.chars_per_synthetic_page
+        then
+            local collapsed, reason = publisherMapClearlyCollapsed(document)
+            if collapsed then
+                local chars = getSyntheticChars(self)
+                logger.warn(
+                    "Burrow stable page numbers: publisher page map is collapsed; using synthetic map instead:",
+                    reason
                 )
+                -- The publisher map was already registered by KOReader's
+                -- _postInit(), so rebuilding it does not require registering the
+                -- same view module a second time.
+                installSyntheticMap(self, document, chars, false)
             end
+        end
+
+        -- If KOReader has no page map at all, preserve Burrow's existing default:
+        -- create a stable synthetic map for reflowable documents.
+        if not self.has_pagemap then
+            local chars = getSyntheticChars(self)
+            installSyntheticMap(self, document, chars, true)
         end
 
         if self.has_pagemap then


### PR DESCRIPTION
Book-specific stable page-number hardening for 0.4.8.

Observed failure:
- Some EPUBs expose a publisher page map that KOReader accepts as valid.
- In the reported book, every reading position resolves to the same label (`ii`) even though KOReader reports hundreds of page-map entries.
- Other books continue to number normally.

Beta 6 change:
- Keep publisher page maps preferred by default.
- Validate only document-provided maps, never user-selected or existing synthetic maps.
- Do not judge labels or numbering style. Roman numerals and unusual labels remain valid.
- Treat a publisher map as collapsed only when it is reasonably large and its anchors are objectively broken: almost all entries reuse one or two XPointers, or anchors sampled across the whole map resolve into only a tiny portion of a reasonably large rendered document.
- When a map is clearly collapsed, replace it with Burrow's existing synthetic page map using the normal characters-per-page value (default 1500) and save that synthetic choice for the book.
- Good publisher maps and all existing synthetic maps are left untouched.

Device test:
1. Open the affected EPUB that previously showed `Page ii of 309` on every page.
2. After restart/update, confirm the footer advances through numeric stable pages instead of remaining on `ii`.
3. Turn through multiple chapters and confirm numbering progresses.
4. Reopen the book and confirm the synthetic fallback persists.
5. Open several books with known-good publisher page numbers and confirm those publisher labels are unchanged.
6. Open books using Burrow-generated synthetic numbering and confirm they are unchanged.