### PR TITLE
Burrow 0.4.8 beta 7: reject out-of-order publisher page maps

### DIFF
--- a/plugins/burrow.koplugin/burrow_version.lua
+++ b/plugins/burrow.koplugin/burrow_version.lua
@@ -1,6 +1,6 @@
 return {
-    VERSION = "0.4.8-beta.6",
-    DISPLAY_VERSION = "0.4.8-beta.6",
+    VERSION = "0.4.8-beta.7",
+    DISPLAY_VERSION = "0.4.8-beta.7",
     STORE_ENGINE_VERSION = "1.2.3",
 
     -- Burrow is tested against KOReader 2026.07.2. Older releases are blocked,

--- a/plugins/burrow.koplugin/internal_patches/2-stable-page-numbers.lua
+++ b/plugins/burrow.koplugin/internal_patches/2-stable-page-numbers.lua
@@ -14,12 +14,13 @@ function Module.apply()
 
     local ReaderPageMap = require("apps/reader/modules/readerpagemap")
     local logger = require("logger")
-    if ReaderPageMap._burrow_stable_page_numbers_v2 then
+    if ReaderPageMap._burrow_stable_page_numbers_v3 then
         Module.applied = true
         return true
     end
     ReaderPageMap._burrow_stable_page_numbers_v1 = true
     ReaderPageMap._burrow_stable_page_numbers_v2 = true
+    ReaderPageMap._burrow_stable_page_numbers_v3 = true
 
     local DEFAULT_CHARS_PER_PAGE = 1500
     local original_onReadSettings = ReaderPageMap.onReadSettings
@@ -74,19 +75,21 @@ function Module.apply()
         end
     end
 
-    -- A publisher map is considered broken only when its anchors are objectively
-    -- collapsed. Labels themselves are not inspected: Roman numerals, duplicate
-    -- labels, unusual numbering schemes and partial front matter are all valid.
+    -- Publisher maps are kept unless their anchors are objectively unusable.
+    -- Labels themselves are never judged: Roman numerals, duplicate labels,
+    -- unusual numbering schemes and partial front matter are all valid.
     --
-    -- We deliberately require a large map and document. Then we use two
-    -- independent, conservative signals:
-    --   1. almost all map entries literally reuse one or two XPointers; or
-    --   2. anchors sampled across the entire map all resolve into essentially the
+    -- We deliberately require a large map and document, then use three
+    -- conservative signals:
+    --   1. ordered anchors make a large backwards jump through the rendered
+    --      document, which violates page-list reading order;
+    --   2. almost all map entries literally reuse one or two XPointers; or
+    --   3. anchors sampled across the entire map resolve into essentially the
     --      same tiny rendered-page span.
     --
-    -- This catches maps that report hundreds of entries while every reading
-    -- position resolves to one early label, without second-guessing healthy maps.
-    local function publisherMapClearlyCollapsed(document)
+    -- This catches malformed publisher maps without second-guessing healthy
+    -- print pagination.
+    local function publisherMapClearlyBroken(document)
         local ok, page_list = pcall(document.getPageMap, document)
         if not ok or type(page_list) ~= "table" then
             return false
@@ -101,6 +104,33 @@ function Module.apply()
         rendered_pages = ok_pages and tonumber(rendered_pages) or 0
         if not rendered_pages or rendered_pages < 40 then
             return false
+        end
+
+        -- EPUB page-list targets are required to follow reading order. Allow
+        -- equal pages and small layout noise, but a substantial backwards jump
+        -- means the map cannot be used safely by CRengine's ordered lookup.
+        local backward_limit = math.max(8, math.floor(rendered_pages * 0.10))
+        local previous_page
+        local previous_index
+        for index, entry in ipairs(page_list) do
+            local xp = type(entry) == "table" and entry.xpointer or nil
+            if type(xp) == "string" and xp ~= "" then
+                local resolved_ok, page = pcall(document.getPageFromXPointer, document, xp)
+                page = resolved_ok and tonumber(page) or nil
+                if page then
+                    if previous_page and previous_page - page >= backward_limit then
+                        return true, string.format(
+                            "page-map anchor %d resolves to rendered page %d after anchor %d resolved to page %d",
+                            index,
+                            page,
+                            previous_index,
+                            previous_page
+                        )
+                    end
+                    previous_page = page
+                    previous_index = index
+                end
+            end
         end
 
         local xpointer_count = 0
@@ -190,17 +220,17 @@ function Module.apply()
         local document = self.ui.document
 
         -- KOReader normally prefers a publisher-supplied page map. Keep that
-        -- preference unless the publisher map is clearly collapsed. A synthetic
+        -- preference unless the publisher map is clearly broken. A synthetic
         -- map already selected by the user is never validated or replaced here.
         if self.has_pagemap
             and self.has_pagemap_document_provided
             and not self.chars_per_synthetic_page
         then
-            local collapsed, reason = publisherMapClearlyCollapsed(document)
-            if collapsed then
+            local broken, reason = publisherMapClearlyBroken(document)
+            if broken then
                 local chars = getSyntheticChars(self)
                 logger.warn(
-                    "Burrow stable page numbers: publisher page map is collapsed; using synthetic map instead:",
+                    "Burrow stable page numbers: publisher page map is broken; using synthetic map instead:",
                     reason
                 )
                 -- The publisher map was already registered by KOReader's


### PR DESCRIPTION
Fixes the specific EPUB supplied for the repeated `Page ii of 309` failure.

Root cause confirmed from the EPUB itself:
- Its EPUB3 page-list starts with `ii -> ad-card.xhtml#pageii`.
- `ad-card.xhtml` is second-to-last in the spine.
- The next page-list entry is `iii -> titlepage.xhtml#pageiii`, near the beginning of the spine.
- The remaining page markers then proceed normally through the book.
- This means the publisher page-list makes a huge backwards jump in reading order. CRengine's ordered current-page lookup can then resolve every position to the early `ii` label.

Beta 7 change:
- Preserve beta 6's conservative collapsed-map checks.
- Add a third, objective publisher-map validation: resolve page-map anchors in listed order and reject the map only when there is a substantial backwards jump through the rendered document.
- Equal rendered pages and small layout noise remain valid.
- Labels are still not judged, so Roman numerals and unusual publisher numbering remain supported.
- When rejected, use Burrow's existing synthetic stable page map and persist that choice for the book.
- Existing synthetic maps and healthy publisher maps are unchanged.

Device test:
1. Update from beta 6 to beta 7 and restart KOReader.
2. Reopen the supplied affected EPUB.
3. Confirm `Page ii of 309` is replaced by progressing synthetic stable page numbers.
4. Jump well into the book and confirm the stable page advances.
5. Close and reopen the EPUB and confirm the fallback persists.
6. Spot-check books with valid publisher page numbers and normal synthetic numbering for regressions.