### PR TITLE
Burrow 0.4.8 beta 9: always use synthetic EPUB page numbers

### DIFF
--- a/plugins/burrow.koplugin/burrow_version.lua
+++ b/plugins/burrow.koplugin/burrow_version.lua
@@ -1,6 +1,6 @@
 return {
-    VERSION = "0.4.8-beta.8",
-    DISPLAY_VERSION = "0.4.8-beta.8",
+    VERSION = "0.4.8-beta.9",
+    DISPLAY_VERSION = "0.4.8-beta.9",
     STORE_ENGINE_VERSION = "1.2.3",
 
     -- Burrow is tested against KOReader 2026.07.2. Older releases are blocked,

--- a/plugins/burrow.koplugin/internal_patches/2-stable-page-numbers.lua
+++ b/plugins/burrow.koplugin/internal_patches/2-stable-page-numbers.lua
@@ -14,7 +14,7 @@ function Module.apply()
 
     local ReaderPageMap = require("apps/reader/modules/readerpagemap")
     local logger = require("logger")
-    if ReaderPageMap._burrow_stable_page_numbers_v4 then
+    if ReaderPageMap._burrow_stable_page_numbers_v5 then
         Module.applied = true
         return true
     end
@@ -22,6 +22,7 @@ function Module.apply()
     ReaderPageMap._burrow_stable_page_numbers_v2 = true
     ReaderPageMap._burrow_stable_page_numbers_v3 = true
     ReaderPageMap._burrow_stable_page_numbers_v4 = true
+    ReaderPageMap._burrow_stable_page_numbers_v5 = true
 
     local DEFAULT_CHARS_PER_PAGE = 1500
     local original_onReadSettings = ReaderPageMap.onReadSettings
@@ -41,12 +42,28 @@ function Module.apply()
         return chars
     end
 
+    local function isEpubDocument(document)
+        local file = document and document.file
+        if type(file) ~= "string" then
+            return false
+        end
+        return file:lower():match("%.epub$") ~= nil
+    end
+
     local function isSyntheticMap(document)
         if not document or type(document.isPageMapSynthetic) ~= "function" then
             return false
         end
         local ok, value = pcall(document.isPageMapSynthetic, document)
         return ok and value == true
+    end
+
+    local function getActiveSyntheticChars(document)
+        if not document or type(document.getSyntheticPageMapCharsPerPage) ~= "function" then
+            return 0
+        end
+        local ok, value = pcall(document.getSyntheticPageMapCharsPerPage, document)
+        return ok and (tonumber(value) or 0) or 0
     end
 
     local function installSyntheticMap(self, document, chars, register_view)
@@ -56,10 +73,8 @@ function Module.apply()
             return false
         end
 
-        -- A publisher map already makes hasPageMap() true, so that alone cannot
-        -- prove the replacement succeeded. Verify the active map itself.
         if not isSyntheticMap(document) then
-            logger.warn("Burrow stable page numbers: synthetic page-map build did not replace the active map")
+            logger.warn("Burrow stable page numbers: synthetic page-map build did not become active")
             return false
         end
 
@@ -76,130 +91,6 @@ function Module.apply()
             select(3, self:getCurrentPageLabel())
         )
         return true
-    end
-
-    local function addSampleIndex(indices, seen, index, total)
-        if index < 1 then index = 1 end
-        if index > total then index = total end
-        if not seen[index] then
-            seen[index] = true
-            indices[#indices + 1] = index
-        end
-    end
-
-    -- Publisher maps are kept unless the map KOReader is actually using is
-    -- objectively unusable. getPageMap() already gives each entry's rendered
-    -- page as entry.page, so validate that directly instead of resolving the
-    -- stored XPointer a second time.
-    local function publisherMapClearlyBroken(document)
-        local ok, page_list = pcall(document.getPageMap, document)
-        if not ok or type(page_list) ~= "table" then
-            return false
-        end
-
-        local total = #page_list
-        if total < 40 then
-            return false
-        end
-
-        local ok_pages, rendered_pages = pcall(document.getPages, document)
-        rendered_pages = ok_pages and tonumber(rendered_pages) or 0
-        if not rendered_pages or rendered_pages < 40 then
-            return false
-        end
-
-        -- EPUB page-list targets must follow reading order. Equal rendered pages
-        -- are normal, and tiny reversals can happen around layout boundaries, but
-        -- a large backwards jump is not a usable ordered page map.
-        local backward_limit = math.max(8, math.floor(rendered_pages * 0.10))
-        local previous_page
-        local previous_index
-        local page_value_count = 0
-        for index, entry in ipairs(page_list) do
-            local page = type(entry) == "table" and tonumber(entry.page) or nil
-            if page then
-                page_value_count = page_value_count + 1
-                if previous_page and previous_page - page >= backward_limit then
-                    return true, string.format(
-                        "page-map entry %d is rendered page %d after entry %d was page %d",
-                        index,
-                        page,
-                        previous_index,
-                        previous_page
-                    )
-                end
-                previous_page = page
-                previous_index = index
-            end
-        end
-
-        -- getPageMap() is expected to provide rendered-page values for its
-        -- entries. If a large map somehow does not, avoid guessing and leave it
-        -- alone rather than replacing a publisher map on weak evidence.
-        if page_value_count < math.min(20, total) then
-            return false
-        end
-
-        local xpointer_count = 0
-        local unique_xpointers = {}
-        local unique_xpointer_count = 0
-        for _, entry in ipairs(page_list) do
-            local xp = type(entry) == "table" and entry.xpointer or nil
-            if type(xp) == "string" and xp ~= "" then
-                xpointer_count = xpointer_count + 1
-                if not unique_xpointers[xp] then
-                    unique_xpointers[xp] = true
-                    unique_xpointer_count = unique_xpointer_count + 1
-                end
-            end
-        end
-
-        if xpointer_count >= 40 then
-            local duplicate_limit = math.max(2, math.floor(xpointer_count * 0.03))
-            if unique_xpointer_count <= duplicate_limit then
-                return true, string.format(
-                    "%d page-map entries use only %d distinct anchors",
-                    xpointer_count,
-                    unique_xpointer_count
-                )
-            end
-        end
-
-        local indices = {}
-        local seen = {}
-        for step = 0, 8 do
-            local index = 1 + math.floor((total - 1) * step / 8)
-            addSampleIndex(indices, seen, index, total)
-        end
-        table.sort(indices)
-
-        local sampled_count = 0
-        local min_page
-        local max_page
-        for _, index in ipairs(indices) do
-            local entry = page_list[index]
-            local page = type(entry) == "table" and tonumber(entry.page) or nil
-            if page then
-                sampled_count = sampled_count + 1
-                if not min_page or page < min_page then min_page = page end
-                if not max_page or page > max_page then max_page = page end
-            end
-        end
-
-        if sampled_count >= 7 and min_page and max_page then
-            local span = max_page - min_page
-            local collapsed_span = math.max(2, math.floor(rendered_pages * 0.01))
-            if span <= collapsed_span then
-                return true, string.format(
-                    "%d sampled entries span only %d of %d rendered pages",
-                    sampled_count,
-                    span,
-                    rendered_pages
-                )
-            end
-        end
-
-        return false
     end
 
     -- Stable labels should be the normal Burrow presentation for reflowable
@@ -221,37 +112,36 @@ function Module.apply()
         end
 
         local document = self.ui.document
-        local active_is_synthetic = isSyntheticMap(document)
 
-        -- KOReader normally prefers a publisher-supplied page map. Validate it
-        -- only when the active map is still the publisher map. Do not trust
-        -- self.chars_per_synthetic_page as proof that a previous replacement
-        -- actually succeeded.
-        if self.has_pagemap
-            and self.has_pagemap_document_provided
-            and not active_is_synthetic
-        then
-            local broken, reason = publisherMapClearlyBroken(document)
-            if broken then
-                local chars = getSyntheticChars(self)
-                logger.warn(
-                    "Burrow stable page numbers: publisher page map is broken; using synthetic map instead:",
-                    reason
-                )
-                installSyntheticMap(self, document, chars, false)
+        if isEpubDocument(document) then
+            -- Burrow intentionally ignores EPUB publisher page maps. Reflowable
+            -- EPUBs always use a synthetic character-based map so numbering is
+            -- predictable across books, devices and EPUB packaging quirks.
+            local chars = getSyntheticChars(self)
+            local active_is_synthetic = isSyntheticMap(document)
+            local active_chars = getActiveSyntheticChars(document)
+
+            if not active_is_synthetic or active_chars ~= chars then
+                local register_view = not self.has_pagemap
+                installSyntheticMap(self, document, chars, register_view)
+            else
+                self.chars_per_synthetic_page = chars
+                self.has_pagemap = true
             end
-        end
 
-        -- If KOReader has no page map at all, preserve Burrow's existing default:
-        -- create a stable synthetic map for reflowable documents.
-        if not self.has_pagemap then
+            if isSyntheticMap(document) then
+                -- The file may still physically contain publisher page data, but
+                -- Burrow does not expose it as an alternate active page source.
+                self.has_pagemap_document_provided = false
+            end
+        elseif not self.has_pagemap then
+            -- Preserve Burrow's existing behavior for other reflowable formats:
+            -- create synthetic stable pages only when KOReader has no page map.
             local chars = getSyntheticChars(self)
             installSyntheticMap(self, document, chars, true)
         end
 
         if self.has_pagemap then
-            -- The footer, Reading Location, bookmarks and other KOReader
-            -- consumers already switch to page-map labels through this flag.
             self.use_page_labels = true
             self.page_labels_cache = nil
             self.ui.doc_settings:saveSetting("pagemap_use_page_labels", true)


### PR DESCRIPTION
Simplifies Burrow's stable-page policy for reflowable EPUBs.

Beta 9 change:
- Remove the experimental publisher-page-map validation logic added in betas 6-8.
- For reflowable `.epub` documents, always build and use Burrow's synthetic character-based page map.
- Default remains 1500 characters per page, while the existing per-book Characters per page setting remains honored.
- Embedded EPUB publisher page-list data is ignored for active numbering.
- Hide the publisher-map alternate-source state in the current reader session after the synthetic map is active, so Burrow does not advertise `℗` or offer publisher numbering for that EPUB.
- Preserve existing behavior for non-EPUB reflowable formats: synthesize only when KOReader has no page map.
- Fixed-layout formats remain untouched.

This is intentionally simpler and more predictable than trying to identify every malformed publisher page map.

Device test:
1. Update to beta 9 and restart KOReader.
2. Open the affected EPUB that previously stayed on `Page ii of 309`.
3. Confirm it now uses numeric synthetic pages and advances normally through the book.
4. Open several normal EPUBs, including ones that previously had publisher page numbers, and confirm they also use synthetic numbering.
5. Change Characters per page for one EPUB and confirm the new synthetic count persists.
6. Spot-check PDF/CBZ and another non-EPUB reflowable book for unchanged behavior.