### PR TITLE
Promote Burrow 0.4.8 to stable

### DIFF
--- a/plugins/burrow.koplugin/burrow_version.lua
+++ b/plugins/burrow.koplugin/burrow_version.lua
@@ -1,6 +1,6 @@
 return {
-    VERSION = "0.4.8-beta.9",
-    DISPLAY_VERSION = "0.4.8-beta.9",
+    VERSION = "0.4.8",
+    DISPLAY_VERSION = "0.4.8",
     STORE_ENGINE_VERSION = "1.2.3",
 
     -- Burrow is tested against KOReader 2026.07.2. Older releases are blocked,


### PR DESCRIPTION
Promotes the device-tested 0.4.8-beta.9 runtime to stable 0.4.8 with no behavior changes.

Stable 0.4.8 includes the 0.4.8 beta work already tested through beta 9, including:
- independent horizontal and vertical cover spacing, including tighter-than-default spacing;
- automatic hero-card alignment with the final cover span;
- Home pager first-render centering;
- Kindle Wi-Fi recovery improvements and silent KOSync suspend behavior when offline;
- reflowable EPUBs using Burrow synthetic stable page numbers rather than embedded publisher page maps.

This PR changes only VERSION and DISPLAY_VERSION from 0.4.8-beta.9 to 0.4.8. Runtime code is identical to beta 9.