### PR TITLE
Burrow 0.4.9 beta 1: refresh library after Store downloads

### DIFF
--- a/plugins/burrow.koplugin/burrow_store/main.lua
+++ b/plugins/burrow.koplugin/burrow_store/main.lua
@@ -6,6 +6,7 @@ local OPDSBrowser = require("burrow_store.ui.browser")
 local UIManager = require("ui/uimanager")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local lfs = require("libs/libkoreader-lfs")
+local logger = require("logger")
 local util = require("util")
 local _ = require("gettext")
 local T = require("ffi/util").template
@@ -215,8 +216,38 @@ function OPDS:onDispatcherRegisterActions()
     )
 end
 
+-- Store downloads happen while KOReader's file chooser can remain open behind
+-- the Store. The files are already on disk, but the chooser keeps its existing
+-- item table until it is told to rescan the current directory. Schedule the
+-- native refresh on the UI thread after download work returns to the parent
+-- process so newly downloaded books appear without restarting KOReader.
+function OPDS:_refreshLibraryView()
+    local ui = self.ui
+    local file_chooser = ui and ui.file_chooser
+    if not file_chooser or type(file_chooser.refreshPath) ~= "function" then
+        return false
+    end
+
+    UIManager:nextTick(function()
+        if not self.ui or self.ui.file_chooser ~= file_chooser then
+            return
+        end
+
+        local ok, err = pcall(function()
+            if type(file_chooser.clearSortingCache) == "function" then
+                file_chooser:clearSortingCache()
+            end
+            file_chooser:refreshPath()
+        end)
+        if not ok then
+            logger.warn("Burrow Store: could not refresh library after download", err)
+        end
+    end)
+    return true
+end
+
 function OPDS:_createBrowserInstance()
-    return OPDSBrowser:new {
+    local browser = OPDSBrowser:new {
         servers = self.servers,
         downloads = self.downloads,
         settings = self.settings,
@@ -228,6 +259,7 @@ function OPDS:_createBrowserInstance()
         show_covers = true,
         _manager = self,
         file_downloaded_callback = function(file)
+            self:_refreshLibraryView()
             self:showFileDownloadedDialog(file)
         end,
         close_callback = function()
@@ -243,9 +275,26 @@ function OPDS:_createBrowserInstance()
                     self.ui.file_chooser:changeToPath(pathname, self.last_downloaded_file)
                 end
                 self.last_downloaded_file = nil
+            else
+                self:_refreshLibraryView()
             end
         end,
     }
+
+    -- Every Store sync entry point eventually calls this browser method,
+    -- including the visible Store menus and dispatcher/gesture sync actions.
+    -- Refresh only after that synchronous sync/download path returns so the
+    -- parent process sees the completed files before FileChooser rescans.
+    local original_check_sync = browser.checkSyncDownload
+    if type(original_check_sync) == "function" then
+        browser.checkSyncDownload = function(browser_self, ...)
+            local result = original_check_sync(browser_self, ...)
+            self:_refreshLibraryView()
+            return result
+        end
+    end
+
+    return browser
 end
 
 function OPDS:_startSyncFromDispatcher(force_sync)

--- a/plugins/burrow.koplugin/burrow_version.lua
+++ b/plugins/burrow.koplugin/burrow_version.lua
@@ -1,6 +1,6 @@
 return {
-    VERSION = "0.4.8",
-    DISPLAY_VERSION = "0.4.8",
+    VERSION = "0.4.9-beta.1",
+    DISPLAY_VERSION = "0.4.9-beta.1",
     STORE_ENGINE_VERSION = "1.2.3",
 
     -- Burrow is tested against KOReader 2026.07.2. Older releases are blocked,


### PR DESCRIPTION
Fixes newly downloaded OPDS books not appearing in the Burrow library until KOReader restarts, especially on Kindle.

What changes:
- adds a Store-scoped library refresh helper that uses KOReader FileChooser's native `refreshPath()`;
- clears the chooser sorting cache before the rescan so new/replaced books can be sorted with fresh metadata;
- refreshes after Store catalog sync returns, covering visible Store sync controls and dispatcher/gesture sync actions;
- refreshes after individual Store downloads;
- refreshes when leaving the Store after queue/download activity if there is no specific downloaded file being focused;
- schedules the rescan on KOReader's UI thread and isolates refresh failures so Store/download behavior still completes.

What does not change:
- download paths, sync checkpoints, queue persistence, metadata invalidation, cover extraction, Android behavior, or Kindle filesystem behavior;
- stable 0.4.8 remains untouched until this beta is device-tested.

Device test:
1. On Kindle, sync one or more new OPDS books into the active library folder.
2. Return to Home/library without restarting KOReader.
3. Confirm the new books appear immediately and covers/metadata populate normally.
4. Repeat with an individual Store download.
5. Verify Store sync, queue state, and existing books remain intact.