### PR TITLE
Burrow 0.4.9 beta 2: fast dark-mode page turns on e-ink

### DIFF
--- a/plugins/burrow.koplugin/burrow_version.lua
+++ b/plugins/burrow.koplugin/burrow_version.lua
@@ -1,6 +1,6 @@
 return {
-    VERSION = "0.4.9-beta.1",
-    DISPLAY_VERSION = "0.4.9-beta.1",
+    VERSION = "0.4.9-beta.2",
+    DISPLAY_VERSION = "0.4.9-beta.2",
     STORE_ENGINE_VERSION = "1.2.3",
 
     -- Burrow is tested against KOReader 2026.07.2. Older releases are blocked,

--- a/plugins/burrow.koplugin/internal_patches/2-fast-dark-page-turns.lua
+++ b/plugins/burrow.koplugin/internal_patches/2-fast-dark-page-turns.lua
@@ -1,0 +1,83 @@
+local MODULE_KEY = "burrow.internal.2_fast_dark_page_turns"
+local existing_module = package.loaded[MODULE_KEY]
+if existing_module then return existing_module end
+
+local Module = {
+    key = MODULE_KEY,
+    phase = "early",
+    filename = "2-fast-dark-page-turns.lua",
+}
+package.loaded[MODULE_KEY] = Module
+
+local SETTING = "burrow_fast_dark_page_turns"
+local CLEANUP_INTERVAL = 6
+
+local function applyFastDarkPageTurns()
+    local Device = require("device")
+    local Screen = Device.screen
+
+    local eink_ok, is_eink = pcall(Device.hasEinkScreen, Device)
+    if not eink_ok or not is_eink then
+        return true
+    end
+
+    if not Screen or type(Screen.refreshFast) ~= "function" then
+        return true
+    end
+
+    local ReaderView = require("apps/reader/modules/readerview")
+    if ReaderView._burrow_fast_dark_page_turns_v1 then
+        return true
+    end
+
+    local original_on_page_update = ReaderView.onPageUpdate
+    if type(original_on_page_update) ~= "function" then
+        return false, "ReaderView.onPageUpdate is unavailable"
+    end
+
+    ReaderView._burrow_fast_dark_page_turns_v1 = true
+
+    ReaderView.onPageUpdate = function(self, ...)
+        local use_fast = G_reader_settings:isTrue(SETTING)
+            and Screen.night_mode == true
+            and self.ui ~= nil
+            and self.ui.rolling ~= nil
+            and self.view_mode == "page"
+            and self.currently_scrolling ~= true
+
+        if not use_fast then
+            self._burrow_fast_dark_turn_count = 0
+            return original_on_page_update(self, ...)
+        end
+
+        local turn_count = (self._burrow_fast_dark_turn_count or 0) + 1
+        self._burrow_fast_dark_turn_count = turn_count
+
+        -- Keep KOReader's normal higher-fidelity Night Mode refresh regularly.
+        -- Fast refreshes do not advance KOReader's normal partial-refresh
+        -- promotion counter, so this periodic pass also bounds how long fast
+        -- page turns can accumulate visible residue.
+        if turn_count % CLEANUP_INTERVAL == 0 then
+            return original_on_page_update(self, ...)
+        end
+
+        -- ReaderView:recalculate() already requests "fast" whenever its
+        -- currently_scrolling flag is true. Borrow that native path only for
+        -- this PageUpdate call instead of patching UIManager or any framebuffer
+        -- backend. Each e-ink device therefore keeps its own fast waveform.
+        local previous_scrolling = self.currently_scrolling
+        self.currently_scrolling = true
+        local results = { pcall(original_on_page_update, self, ...) }
+        self.currently_scrolling = previous_scrolling
+
+        if not results[1] then
+            error(results[2], 0)
+        end
+        return unpack(results, 2)
+    end
+
+    return true
+end
+
+Module.apply = applyFastDarkPageTurns
+return Module

--- a/plugins/burrow.koplugin/internal_patches/2-fast-dark-page-turns.lua
+++ b/plugins/burrow.koplugin/internal_patches/2-fast-dark-page-turns.lua
@@ -11,6 +11,55 @@ package.loaded[MODULE_KEY] = Module
 
 local SETTING = "burrow_fast_dark_page_turns"
 local CLEANUP_INTERVAL = 6
+local MENU_KEY = "burrow_fast_dark_page_turns"
+
+local function settingEnabled()
+    return G_reader_settings:isTrue(SETTING)
+end
+
+local function addReaderMenuEntry(Screen)
+    local _ = require("gettext")
+    local ReaderRolling = require("apps/reader/modules/readerrolling")
+    local menu_order = require("ui/elements/reader_menu_order")
+
+    if not ReaderRolling._burrow_fast_dark_page_turns_menu_v1 then
+        ReaderRolling._burrow_fast_dark_page_turns_menu_v1 = true
+        local original_add_to_main_menu = ReaderRolling.addToMainMenu
+
+        ReaderRolling.addToMainMenu = function(self, menu_items)
+            original_add_to_main_menu(self, menu_items)
+            menu_items[MENU_KEY] = {
+                text = _("Fast dark-mode page turns"),
+                help_text = _("On e-ink screens, use KOReader's native fast refresh for most reflowable page turns in Night Mode. Every sixth turn keeps the normal Night Mode refresh to limit residue. Light mode, scrolling, PDFs, comics, and menus are unchanged."),
+                checked_func = settingEnabled,
+                callback = function()
+                    G_reader_settings:saveSetting(SETTING, not settingEnabled())
+                end,
+            }
+        end
+    end
+
+    local document_order = type(menu_order) == "table" and menu_order.document or nil
+    if type(document_order) == "table" then
+        local found = false
+        for _, key in ipairs(document_order) do
+            if key == MENU_KEY then
+                found = true
+                break
+            end
+        end
+        if not found then
+            local insert_at = #document_order + 1
+            for index, key in ipairs(document_order) do
+                if key == "partial_rerendering" then
+                    insert_at = index + 1
+                    break
+                end
+            end
+            table.insert(document_order, insert_at, MENU_KEY)
+        end
+    end
+end
 
 local function applyFastDarkPageTurns()
     local Device = require("device")
@@ -25,6 +74,8 @@ local function applyFastDarkPageTurns()
         return true
     end
 
+    addReaderMenuEntry(Screen)
+
     local ReaderView = require("apps/reader/modules/readerview")
     if ReaderView._burrow_fast_dark_page_turns_v1 then
         return true
@@ -38,7 +89,7 @@ local function applyFastDarkPageTurns()
     ReaderView._burrow_fast_dark_page_turns_v1 = true
 
     ReaderView.onPageUpdate = function(self, ...)
-        local use_fast = G_reader_settings:isTrue(SETTING)
+        local use_fast = settingEnabled()
             and Screen.night_mode == true
             and self.ui ~= nil
             and self.ui.rolling ~= nil
@@ -53,10 +104,9 @@ local function applyFastDarkPageTurns()
         local turn_count = (self._burrow_fast_dark_turn_count or 0) + 1
         self._burrow_fast_dark_turn_count = turn_count
 
-        -- Keep KOReader's normal higher-fidelity Night Mode refresh regularly.
         -- Fast refreshes do not advance KOReader's normal partial-refresh
-        -- promotion counter, so this periodic pass also bounds how long fast
-        -- page turns can accumulate visible residue.
+        -- promotion counter. Keep a regular Night Mode refresh periodically so
+        -- the experiment cannot run indefinitely on low-fidelity updates.
         if turn_count % CLEANUP_INTERVAL == 0 then
             return original_on_page_update(self, ...)
         end

--- a/plugins/burrow.koplugin/internal_patches/2-kindle-night-sync.lua
+++ b/plugins/burrow.koplugin/internal_patches/2-kindle-night-sync.lua
@@ -69,12 +69,38 @@ function Module.sync()
     return true
 end
 
+local function patchDirectory()
+    local source = debug.getinfo(1, "S").source
+    return source:match("^@(.+)/[^/]+$")
+end
+
+local function applyFastDarkPageTurns()
+    -- This experiment is e-ink-wide, not Kindle-specific. It is loaded from
+    -- this always-present early module to avoid changing Burrow's established
+    -- early-module ordering. The implementation itself returns immediately on
+    -- non-e-ink screens.
+    local directory = patchDirectory()
+    if not directory then return end
+
+    local ok_load, fast_turns = pcall(dofile, directory .. "/2-fast-dark-page-turns.lua")
+    if not ok_load or type(fast_turns) ~= "table" or type(fast_turns.apply) ~= "function" then
+        local logger = require("logger")
+        logger.warn("[Burrow] Fast dark page turns unavailable", fast_turns)
+        return
+    end
+
+    local ok_apply, result, apply_error = pcall(fast_turns.apply)
+    if not ok_apply or result == false then
+        local logger = require("logger")
+        logger.warn("[Burrow] Fast dark page turns failed; continuing with KOReader defaults", ok_apply and apply_error or result)
+    end
+end
+
 local function applyKindleWifiRecovery()
     -- Keep the Wi-Fi recovery implementation in its own file and guard it here.
     -- A networking compatibility failure must never disable Kindle Night Mode
     -- synchronization or any larger Burrow subsystem.
-    local source = debug.getinfo(1, "S").source
-    local directory = source:match("^@(.+)/[^/]+$")
+    local directory = patchDirectory()
     if not directory then return end
 
     local ok_load, recovery = pcall(dofile, directory .. "/2-kindle-wifi-recovery.lua")
@@ -97,6 +123,7 @@ function Module.apply()
     local ok, err = Module.sync()
     if not ok then return false, err end
 
+    applyFastDarkPageTurns()
     applyKindleWifiRecovery()
 
     Module.applied = true


### PR DESCRIPTION
Adds an opt-in experiment to reduce the slow outlined-text transition seen during Night Mode page turns on e-ink devices.

Scope:
- all devices KOReader reports as e-ink, including Kindle, Kobo, PocketBook and Android e-ink;
- reflowable books in page mode only;
- Night Mode only;
- off by default;
- light mode, scrolling, fixed-layout/PDF/comics, menus and non-e-ink screens remain unchanged.

Implementation:
- reuses ReaderView's existing native `fast` refresh path instead of patching UIManager or framebuffer backends;
- each device therefore keeps KOReader's own `refreshFast`/waveform implementation;
- every sixth page change uses normal KOReader Night Mode refresh to bound low-fidelity residue;
- adds `Settings > Document > Fast dark-mode page turns` in the reader, toggleable without restart;
- loads from the already-established early Night Mode shim without changing the manifest ordering.

Device test:
1. Enable Night Mode on an e-ink reader.
2. Open a reflowable EPUB.
3. Under Settings > Document, enable Fast dark-mode page turns.
4. Turn several pages and compare transition speed/outline phase with the option disabled.
5. Watch the sixth turn for the normal higher-fidelity Night Mode transition.
6. Verify light mode, menus, scrolling, PDF/comic reading and library UI are unchanged.