### PR TITLE
Burrow 0.4.9 beta 3: fast e-ink page turns by default

### DIFF
--- a/plugins/burrow.koplugin/burrow_version.lua
+++ b/plugins/burrow.koplugin/burrow_version.lua
@@ -1,6 +1,6 @@
 return {
-    VERSION = "0.4.9-beta.2",
-    DISPLAY_VERSION = "0.4.9-beta.2",
+    VERSION = "0.4.9-beta.3",
+    DISPLAY_VERSION = "0.4.9-beta.3",
     STORE_ENGINE_VERSION = "1.2.3",
 
     -- Burrow is tested against KOReader 2026.07.2. Older releases are blocked,

--- a/plugins/burrow.koplugin/internal_patches/2-fast-dark-page-turns.lua
+++ b/plugins/burrow.koplugin/internal_patches/2-fast-dark-page-turns.lua
@@ -11,57 +11,14 @@ package.loaded[MODULE_KEY] = Module
 
 local SETTING = "burrow_fast_dark_page_turns"
 local CLEANUP_INTERVAL = 6
-local MENU_KEY = "burrow_fast_dark_page_turns"
 
 local function settingEnabled()
-    return G_reader_settings:isTrue(SETTING)
+    local value = G_reader_settings:readSetting(SETTING)
+    if value == nil then return true end
+    return value == true
 end
 
-local function addReaderMenuEntry(Screen)
-    local _ = require("gettext")
-    local ReaderRolling = require("apps/reader/modules/readerrolling")
-    local menu_order = require("ui/elements/reader_menu_order")
-
-    if not ReaderRolling._burrow_fast_dark_page_turns_menu_v1 then
-        ReaderRolling._burrow_fast_dark_page_turns_menu_v1 = true
-        local original_add_to_main_menu = ReaderRolling.addToMainMenu
-
-        ReaderRolling.addToMainMenu = function(self, menu_items)
-            original_add_to_main_menu(self, menu_items)
-            menu_items[MENU_KEY] = {
-                text = _("Fast dark-mode page turns"),
-                help_text = _("On e-ink screens, use KOReader's native fast refresh for most reflowable page turns in Night Mode. Every sixth turn keeps the normal Night Mode refresh to limit residue. Light mode, scrolling, PDFs, comics, and menus are unchanged."),
-                checked_func = settingEnabled,
-                callback = function()
-                    G_reader_settings:saveSetting(SETTING, not settingEnabled())
-                end,
-            }
-        end
-    end
-
-    local document_order = type(menu_order) == "table" and menu_order.document or nil
-    if type(document_order) == "table" then
-        local found = false
-        for _, key in ipairs(document_order) do
-            if key == MENU_KEY then
-                found = true
-                break
-            end
-        end
-        if not found then
-            local insert_at = #document_order + 1
-            for index, key in ipairs(document_order) do
-                if key == "partial_rerendering" then
-                    insert_at = index + 1
-                    break
-                end
-            end
-            table.insert(document_order, insert_at, MENU_KEY)
-        end
-    end
-end
-
-local function applyFastDarkPageTurns()
+local function applyFastEinkPageTurns()
     local Device = require("device")
     local Screen = Device.screen
 
@@ -73,8 +30,6 @@ local function applyFastDarkPageTurns()
     if not Screen or type(Screen.refreshFast) ~= "function" then
         return true
     end
-
-    addReaderMenuEntry(Screen)
 
     local ReaderView = require("apps/reader/modules/readerview")
     if ReaderView._burrow_fast_dark_page_turns_v1 then
@@ -90,23 +45,22 @@ local function applyFastDarkPageTurns()
 
     ReaderView.onPageUpdate = function(self, ...)
         local use_fast = settingEnabled()
-            and Screen.night_mode == true
             and self.ui ~= nil
             and self.ui.rolling ~= nil
             and self.view_mode == "page"
             and self.currently_scrolling ~= true
 
         if not use_fast then
-            self._burrow_fast_dark_turn_count = 0
+            self._burrow_fast_eink_turn_count = 0
             return original_on_page_update(self, ...)
         end
 
-        local turn_count = (self._burrow_fast_dark_turn_count or 0) + 1
-        self._burrow_fast_dark_turn_count = turn_count
+        local turn_count = (self._burrow_fast_eink_turn_count or 0) + 1
+        self._burrow_fast_eink_turn_count = turn_count
 
         -- Fast refreshes do not advance KOReader's normal partial-refresh
-        -- promotion counter. Keep a regular Night Mode refresh periodically so
-        -- the experiment cannot run indefinitely on low-fidelity updates.
+        -- promotion counter. Keep a regular higher-fidelity refresh periodically
+        -- so low-fidelity page turns cannot accumulate residue indefinitely.
         if turn_count % CLEANUP_INTERVAL == 0 then
             return original_on_page_update(self, ...)
         end
@@ -129,5 +83,5 @@ local function applyFastDarkPageTurns()
     return true
 end
 
-Module.apply = applyFastDarkPageTurns
+Module.apply = applyFastEinkPageTurns
 return Module

--- a/plugins/burrow.koplugin/internal_patches/2-kindle-night-sync.lua
+++ b/plugins/burrow.koplugin/internal_patches/2-kindle-night-sync.lua
@@ -74,25 +74,24 @@ local function patchDirectory()
     return source:match("^@(.+)/[^/]+$")
 end
 
-local function applyFastDarkPageTurns()
-    -- This experiment is e-ink-wide, not Kindle-specific. It is loaded from
-    -- this always-present early module to avoid changing Burrow's established
-    -- early-module ordering. The implementation itself returns immediately on
-    -- non-e-ink screens.
+local function applyFastEinkPageTurns()
+    -- Fast page turns are e-ink-wide, not Kindle-specific. Load them from this
+    -- always-present early module to preserve Burrow's established module order.
+    -- The implementation itself returns immediately on non-e-ink screens.
     local directory = patchDirectory()
     if not directory then return end
 
     local ok_load, fast_turns = pcall(dofile, directory .. "/2-fast-dark-page-turns.lua")
     if not ok_load or type(fast_turns) ~= "table" or type(fast_turns.apply) ~= "function" then
         local logger = require("logger")
-        logger.warn("[Burrow] Fast dark page turns unavailable", fast_turns)
+        logger.warn("[Burrow] Fast e-ink page turns unavailable", fast_turns)
         return
     end
 
     local ok_apply, result, apply_error = pcall(fast_turns.apply)
     if not ok_apply or result == false then
         local logger = require("logger")
-        logger.warn("[Burrow] Fast dark page turns failed; continuing with KOReader defaults", ok_apply and apply_error or result)
+        logger.warn("[Burrow] Fast e-ink page turns failed; continuing with KOReader defaults", ok_apply and apply_error or result)
     end
 end
 
@@ -123,7 +122,7 @@ function Module.apply()
     local ok, err = Module.sync()
     if not ok then return false, err end
 
-    applyFastDarkPageTurns()
+    applyFastEinkPageTurns()
     applyKindleWifiRecovery()
 
     Module.applied = true

--- a/plugins/burrow.koplugin/internal_patches/2-zzzz-soft-palette-settings.lua
+++ b/plugins/burrow.koplugin/internal_patches/2-zzzz-soft-palette-settings.lua
@@ -26,6 +26,7 @@ function Module.apply(plugin)
     local T = require("ffi/util").template
 
     local ORNAMENT_SETTING = "burrow_soft_palette_recolor_ornaments"
+    local FAST_EINK_PAGE_TURNS_SETTING = "burrow_fast_dark_page_turns"
 
     -- Mark the real reader CreDocument before CRengine loads it. The
     -- decorative EPUB shadow loader checks this marker so file-browser cover
@@ -153,6 +154,32 @@ function Module.apply(plugin)
         local value = G_reader_settings:readSetting(SPLIT_FOOTER_ENABLED)
         if value == nil then return true end
         return value == true
+    end
+
+    local function fastEinkPageTurnsEnabled()
+        local value = G_reader_settings:readSetting(FAST_EINK_PAGE_TURNS_SETTING)
+        if value == nil then return true end
+        return value == true
+    end
+
+    local function hasEinkScreen()
+        local ok, value = pcall(Device.hasEinkScreen, Device)
+        return ok and value == true
+    end
+
+    local function fastEinkPageTurnsItem()
+        if not hasEinkScreen() then return nil end
+        return {
+            text = _("Fast e-ink page turns"),
+            help_text = _("Use KOReader's native fast e-ink refresh for most reflowable page turns in both light and dark mode. Every sixth turn uses the normal refresh to limit residue. Scrolling, PDFs, comics, menus, and non-e-ink screens are unchanged."),
+            checked_func = fastEinkPageTurnsEnabled,
+            callback = function()
+                G_reader_settings:saveSetting(
+                    FAST_EINK_PAGE_TURNS_SETTING,
+                    not fastEinkPageTurnsEnabled()
+                )
+            end,
+        }
     end
 
     local function readChoice(key, default)
@@ -411,10 +438,17 @@ function Module.apply(plugin)
             -- another module was not discoverable at menu-build time.
             reading_progress = reading_progress or fallbackReadingProgressMenu()
 
+            local reading_items = {}
+            local fast_page_turns = fastEinkPageTurnsItem()
+            if fast_page_turns then
+                reading_items[#reading_items + 1] = fast_page_turns
+            end
+            reading_items[#reading_items + 1] = reading_progress
+
             local reading = {
                 text = _("Reading"),
                 _burrow_reading_settings = true,
-                sub_item_table = { reading_progress },
+                sub_item_table = reading_items,
             }
 
             local insert_at = #items + 1


### PR DESCRIPTION
Promotes the successful beta 2 page-turn experiment into a normal Burrow reading option.

Changes:
- renames the user-facing option to `Fast e-ink page turns`;
- enables it by default on KOReader-recognized e-ink devices while preserving any explicit beta 2 on/off choice;
- applies the fast refresh path to reflowable page turns in both light and dark mode;
- keeps the normal higher-fidelity refresh every sixth turn to limit residue;
- removes the duplicate KOReader Settings > Document entry;
- exposes the toggle under Burrow Settings > Reading instead;
- leaves scrolling, PDFs/comics, menus, non-e-ink devices, and the library unchanged.

The beta 2 device result on Kindle was reported as working great. Beta 3 still needs on-device confirmation for the new light-mode behavior and menu placement.