### PR TITLE
Promote Burrow 0.4.9 to stable

### DIFF
--- a/plugins/burrow.koplugin/burrow_version.lua
+++ b/plugins/burrow.koplugin/burrow_version.lua
@@ -1,6 +1,6 @@
 return {
-    VERSION = "0.4.9-beta.3",
-    DISPLAY_VERSION = "0.4.9-beta.3",
+    VERSION = "0.4.9",
+    DISPLAY_VERSION = "0.4.9",
     STORE_ENGINE_VERSION = "1.2.3",
 
     -- Burrow is tested against KOReader 2026.07.2. Older releases are blocked,


### PR DESCRIPTION
Promotes the device-tested 0.4.9-beta.3 runtime to stable 0.4.9 with no behavioral changes.

Regression review before promotion:
- compared v0.4.8 to current main;
- no files were deleted;
- the complete `plugins/burrow.koplugin/icons` tree is byte-for-byte identical to v0.4.8 (same Git tree SHA);
- the `resources` tree is unchanged;
- `main.lua`, the core loader, library/cover/hero/topbar modules, Quick Settings icons, and existing visual assets are unchanged;
- beta 3 validation and updater-regression suites passed;
- beta 3 package built successfully;
- user confirmed the beta 2 fast-refresh behavior works great on Kindle, and beta 3 only broadens that tested path to light mode, defaults it on for e-ink, and moves its toggle into the existing Burrow Settings > Reading menu.

This PR changes only VERSION and DISPLAY_VERSION from `0.4.9-beta.3` to `0.4.9`.