### PR TITLE
Burrow 0.4.10 beta 2: expand hero spacing range

### DIFF
--- a/plugins/burrow.koplugin/burrow_version.lua
+++ b/plugins/burrow.koplugin/burrow_version.lua
@@ -1,6 +1,6 @@
 return {
-    VERSION = "0.4.10-beta.1",
-    DISPLAY_VERSION = "0.4.10-beta.1",
+    VERSION = "0.4.10-beta.2",
+    DISPLAY_VERSION = "0.4.10-beta.2",
     STORE_ENGINE_VERSION = "1.2.3",
 
     -- Burrow is tested against KOReader 2026.07.2. Older releases are blocked,

--- a/plugins/burrow.koplugin/internal_patches/2-zzzzz-hero-card-settings.lua
+++ b/plugins/burrow.koplugin/internal_patches/2-zzzzz-hero-card-settings.lua
@@ -33,10 +33,9 @@ local function applyHeroCardSettings(plugin)
 
     local HERO_BOOK_SPACING_SETTING = "burrow_hero_book_spacing"
     local DEFAULT_HERO_BOOK_SPACING = 0
-    -- The current hero keeps roughly thirteen scaled pixels of clear space
-    -- below the card. Stop just short of consuming that safety margin so a
-    -- negative value can tighten the layout without allowing card/grid overlap.
-    local MIN_HERO_BOOK_SPACING = -12
+    -- Match the signed range used by the existing horizontal and vertical
+    -- cover-spacing controls so all three spacing controls behave consistently.
+    local MIN_HERO_BOOK_SPACING = -30
     local MAX_HERO_BOOK_SPACING = 30
 
     local function round(value)
@@ -113,7 +112,7 @@ local function applyHeroCardSettings(plugin)
     -- Keep the existing hero, card size, cover grid, and touch geometry intact.
     -- We only adjust the vertical height reported by the composite hero titlebar.
     -- Positive values reserve extra blank room below the card; negative values
-    -- consume only the card's existing safe bottom margin and bring row one up.
+    -- reduce the reserved height and bring row one closer to the hero.
     local function installHeroBookSpacing()
         local titlebar_index = findUpvalueIndex(CoverMenu.setupLayout, "TitleBar")
         local HeroTitleBar = titlebar_index


### PR DESCRIPTION
Expands the new Hero to books spacing control from -12..30 to -30..30 so it matches Burrow's existing horizontal and vertical cover-spacing controls.

No other geometry or runtime behavior changes are included. Version is bumped to 0.4.10-beta.2 because beta.1 has already been published.