### PR TITLE
Burrow 0.4.10 stable

### DIFF
--- a/plugins/burrow.koplugin/burrow_version.lua
+++ b/plugins/burrow.koplugin/burrow_version.lua
@@ -1,6 +1,6 @@
 return {
-    VERSION = "0.4.10-beta.2",
-    DISPLAY_VERSION = "0.4.10-beta.2",
+    VERSION = "0.4.10",
+    DISPLAY_VERSION = "0.4.10",
     STORE_ENGINE_VERSION = "1.2.3",
 
     -- Burrow is tested against KOReader 2026.07.2. Older releases are blocked,


### PR DESCRIPTION
Promotes the device-tested 0.4.10-beta.2 runtime to stable 0.4.10.

This is a version-only promotion. Runtime code, icons, resources, settings behavior, and the tested hero-to-books spacing implementation are unchanged from beta.2.